### PR TITLE
Sync release 20260531 140904

### DIFF
--- a/.github/workflows/refresh-firebase-token.yml
+++ b/.github/workflows/refresh-firebase-token.yml
@@ -17,7 +17,8 @@ jobs:
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_API_KEY: ${{ secrets.SUPABASE_API_KEY }}
+          SUPABASE_JWT: ${{ secrets.SUPABASE_JWT }}
         with:
           script: |
             const crypto = require('crypto');
@@ -68,14 +69,15 @@ jobs:
 
             // ── 4. Atualizar firebase_config no Supabase ─────────────────────
             const supabaseUrl = process.env.SUPABASE_URL.replace(/\/$/, '');
-            const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+            const supabaseApiKey = process.env.SUPABASE_API_KEY;
+            const supabaseJwt = process.env.SUPABASE_JWT;
 
             const rpcRes = await fetch(`${supabaseUrl}/rest/v1/rpc/update_firebase_token`, {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
-                'apikey': supabaseKey,
-                'Authorization': `Bearer ${supabaseKey}`,
+                'apikey': supabaseApiKey,
+                'Authorization': `Bearer ${supabaseJwt}`,
               },
               body: JSON.stringify({
                 p_access_token: access_token,


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for refreshing the Firebase token, specifically improving how Supabase credentials are managed and used. The main changes involve replacing the use of the Supabase service role key with more granular API key and JWT environment variables, and updating the authentication headers accordingly.

Credential and environment variable updates:

* Replaced the `SUPABASE_SERVICE_ROLE_KEY` environment variable with `SUPABASE_API_KEY` and `SUPABASE_JWT` for improved clarity and separation of credentials in `.github/workflows/refresh-firebase-token.yml`.

API request authentication changes:

* Updated the Supabase authentication headers in the workflow script to use `SUPABASE_API_KEY` for the `apikey` header and `SUPABASE_JWT` for the `Authorization` header, instead of using the service role key for both.