### PR TITLE
Sync release 20260531 141633

### DIFF
--- a/.github/workflows/refresh-firebase-token.yml
+++ b/.github/workflows/refresh-firebase-token.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Gerar token OAuth2 e atualizar Supabase
         uses: actions/github-script@v7
         env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_API_KEY: ${{ secrets.SUPABASE_API_KEY }}


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by setting an environment variable to force JavaScript actions to use Node.js 24.

- Workflow environment update:
  * Added the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable to ensure that JavaScript actions run with Node.js 24 in the `.github/workflows/refresh-firebase-token.yml` workflow.