### PR TITLE
fix: tela em branco ao selecionar gênero no mobile

### DIFF
--- a/src/components/auth/form-sections/personal-info/GenderField.tsx
+++ b/src/components/auth/form-sections/personal-info/GenderField.tsx
@@ -1,7 +1,8 @@
 
 import React from 'react';
 import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
 import { UseFormReturn } from 'react-hook-form';
 
 interface GenderFieldProps {
@@ -16,20 +17,22 @@ export const GenderField = ({ form }: GenderFieldProps) => {
       render={({ field }) => (
         <FormItem>
           <FormLabel className="text-gray-700">Selecione o Gênero</FormLabel>
-          <Select
-            onValueChange={field.onChange}
-            defaultValue={field.value || "Masculino"}
-          >
-            <FormControl>
-              <SelectTrigger className="bg-white text-gray-900">
-                <SelectValue placeholder="Selecione o gênero" />
-              </SelectTrigger>
-            </FormControl>
-            <SelectContent className="bg-white">
-              <SelectItem value="Masculino">Masculino</SelectItem>
-              <SelectItem value="Feminino">Feminino</SelectItem>
-            </SelectContent>
-          </Select>
+          <FormControl>
+            <RadioGroup
+              onValueChange={field.onChange}
+              value={field.value || "Masculino"}
+              className="flex gap-6 pt-1"
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="Masculino" id="genero-masculino" />
+                <Label htmlFor="genero-masculino" className="cursor-pointer font-normal text-gray-900">Masculino</Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="Feminino" id="genero-feminino" />
+                <Label htmlFor="genero-feminino" className="cursor-pointer font-normal text-gray-900">Feminino</Label>
+              </div>
+            </RadioGroup>
+          </FormControl>
           <FormMessage />
         </FormItem>
       )}


### PR DESCRIPTION
## Problema

Em dispositivos móveis, ao selecionar 'Feminino' no cadastro, a tela ficava em branco impedindo o cadastro.

## Causa raiz

O GenderField usava Select do Radix UI (renderiza via Portal). No mobile, o fechamento do Portal após seleção pode deixar o overlay montado ou causar problema de viewport, resultando em tela em branco. Ocorria especificamente com 'Feminino' pois 'Masculino' é o defaultValue — o onValueChange só dispara quando o valor muda.

## Solução

Substituído Select por RadioGroup (sem Portal, sem dropdown, sem problema mobile). Melhor UX para escolha binária. Pacote e componente já existiam no projeto.