### PR TITLE
fix: refetch filiais corretamente ao clicar 'Tentar novamente'

### DIFF
--- a/src/components/auth/form-sections/location/LocationSelector.tsx
+++ b/src/components/auth/form-sections/location/LocationSelector.tsx
@@ -24,7 +24,8 @@ export const LocationSelector = ({ form, disabled = false, context = 'default' }
     setSelectedCountry,
     setSelectedState,
     isLoading,
-    error
+    error,
+    refetch
   } = useLocationSelection('Brasil');
 
   // Sync form values with hook state
@@ -51,12 +52,9 @@ export const LocationSelector = ({ form, disabled = false, context = 'default' }
     form.setValue('branchId', '');
   }, [form, setSelectedState]);
 
-  // Handle retry when error occurs
   const handleRetry = useCallback(() => {
-    console.log('Manually retrying branch fetch...');
-    // The useQuery will handle retry automatically
-    window.location.reload();
-  }, []);
+    refetch();
+  }, [refetch]);
 
   // Map branches to the format expected by BranchSelector
   const branchesForSelector = branches.map(b => ({

--- a/src/hooks/useLocationSelection.ts
+++ b/src/hooks/useLocationSelection.ts
@@ -1,7 +1,7 @@
 /**
  * Hook para seleção de localização (País → Estado → Filial)
- * Usa a mesma abordagem da web - busca direta da tabela filiais
- * Inclui fallback com fetch direto quando o Supabase client falha
+ * Usa fetch direto com header apikey (sem Authorization: Bearer)
+ * pois a anon key do servidor não é um JWT padrão.
  */
 
 import { useState, useMemo, useCallback } from 'react';
@@ -32,6 +32,7 @@ interface UseLocationSelectionReturn {
     // Loading states
     isLoading: boolean;
     error: Error | null;
+    refetch: () => void;
 }
 
 // A chave anon do servidor não é um JWT padrão — o cliente Supabase envia
@@ -63,8 +64,8 @@ export const useLocationSelection = (defaultCountry: string = 'Brasil'): UseLoca
     const [selectedCountry, setSelectedCountryState] = useState<string>(defaultCountry);
     const [selectedState, setSelectedStateState] = useState<string>('');
 
-    // Fetch all branches with fallback
-    const { data: allBranches = [], isLoading, error } = useQuery({
+    // Fetch all branches
+    const { data: allBranches = [], isLoading, error, refetch } = useQuery({
         queryKey: ['all-branches-for-location'],
         queryFn: fetchBranches,
         staleTime: 60000, // Cache for 1 minute
@@ -132,5 +133,6 @@ export const useLocationSelection = (defaultCountry: string = 'Brasil'): UseLoca
         setSelectedState,
         isLoading,
         error: error as Error | null,
+        refetch,
     };
 };


### PR DESCRIPTION
O botão 'Tentar novamente' no erro de cadastro fazia window.location.reload() — recarregava a página inteira ao invés de refazer apenas a query. Agora chama refetch() do react-query, que é mais rápido e não perde o estado do formulário.