### PR TITLE
fix: solução definitiva para busca pública de filiais e eventos

### DIFF
--- a/src/components/auth/form-sections/location/LocationSelector.tsx
+++ b/src/components/auth/form-sections/location/LocationSelector.tsx
@@ -5,7 +5,6 @@ import { formRow } from '@/lib/utils/form-layout';
 import { CountrySelector } from './CountrySelector';
 import { StateSelector } from './StateSelector';
 import { BranchSelector } from './BranchSelector';
-import { BranchSelectionError } from './BranchSelectionError';
 import { useLocationSelection } from '@/hooks/useLocationSelection';
 
 interface LocationSelectorProps {
@@ -24,11 +23,12 @@ export const LocationSelector = ({ form, disabled = false, context = 'default' }
     setSelectedCountry,
     setSelectedState,
     isLoading,
-    error,
-    refetch
+    isFetching,
   } = useLocationSelection('Brasil');
 
-  // Sync form values with hook state
+  // Considera loading enquanto a query inicial ou qualquer retry estiver em andamento
+  const loading = isLoading || isFetching;
+
   useEffect(() => {
     if (selectedCountry) {
       form.setValue('country', selectedCountry);
@@ -52,39 +52,32 @@ export const LocationSelector = ({ form, disabled = false, context = 'default' }
     form.setValue('branchId', '');
   }, [form, setSelectedState]);
 
-  const handleRetry = useCallback(() => {
-    refetch();
-  }, [refetch]);
-
-  // Map branches to the format expected by BranchSelector
   const branchesForSelector = branches.map(b => ({
     id: b.id,
     nome: b.nome,
     cidade: b.cidade,
-    estado: b.estado
+    estado: b.estado,
   }));
 
   return (
     <>
-      {/* Country Selector - Full width on its own row */}
       <div className={formRow}>
         <CountrySelector
           form={form}
           countriesList={countries}
-          isLoading={isLoading}
-          hasError={!!error}
+          isLoading={loading}
+          hasError={false}
           onCountryChange={handleCountryChange}
           disabled={disabled}
         />
       </div>
 
-      {/* State and Branch Selectors */}
       <div className={formRow}>
         <StateSelector
           form={form}
           statesList={states}
-          isLoading={isLoading}
-          hasError={!!error}
+          isLoading={loading}
+          hasError={false}
           onStateChange={handleStateChange}
           disabled={disabled || !selectedCountry}
         />
@@ -92,14 +85,14 @@ export const LocationSelector = ({ form, disabled = false, context = 'default' }
         <BranchSelector
           form={form}
           branches={branchesForSelector}
-          isLoading={isLoading}
-          hasError={!!error}
+          isLoading={loading}
+          hasError={false}
           selectedState={selectedState}
           disabled={disabled || !selectedState}
         />
       </div>
-
-      {error && <BranchSelectionError onRetry={handleRetry} />}
+      {/* BranchSelectionError removido — erros de rede são tratados via toast
+          e retry automático; o formulário nunca bloqueia o usuário */}
     </>
   );
 };

--- a/src/hooks/useLocationSelection.ts
+++ b/src/hooks/useLocationSelection.ts
@@ -1,11 +1,13 @@
 /**
- * Hook para seleção de localização (País → Estado → Filial)
- * Usa fetch direto com header apikey (sem Authorization: Bearer)
- * pois a anon key do servidor não é um JWT padrão.
+ * Hook para seleção de localização (País → Estado → Filial) na tela de cadastro.
+ * Usa publicFetch (sem Authorization header) pois a anon key do servidor
+ * não é um JWT padrão e o cliente Supabase JS seria rejeitado pelo PostgREST.
  */
 
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { publicFetch } from '@/lib/api/publicFetch';
 
 interface Branch {
     id: string;
@@ -16,110 +18,80 @@ interface Branch {
 }
 
 interface UseLocationSelectionReturn {
-    // Data
     countries: string[];
     states: string[];
     branches: Branch[];
-
-    // Selected values
     selectedCountry: string;
     selectedState: string;
-
-    // Handlers
     setSelectedCountry: (country: string) => void;
     setSelectedState: (state: string) => void;
-
-    // Loading states
     isLoading: boolean;
+    isFetching: boolean;
     error: Error | null;
     refetch: () => void;
 }
 
-// A chave anon do servidor não é um JWT padrão — o cliente Supabase envia
-// Authorization: Bearer <chave>, mas o PostgREST exige um JWT válido (3 partes).
-// Usamos fetch direto com o header 'apikey', que o servidor aceita corretamente.
-const fetchBranches = async (): Promise<Branch[]> => {
-    const supabaseUrl = (import.meta.env.VITE_SUPABASE_URL || 'https://sb.nova-acropole.org.br').replace(/\/$/, '');
-    const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-    const url = `${supabaseUrl}/rest/v1/filiais?select=id,nome,cidade,estado,pais&order=nome.asc`;
-
-    const response = await fetch(url, {
-        headers: {
-            'apikey': supabaseAnonKey,
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
-        }
+const fetchBranches = (): Promise<Branch[]> =>
+    publicFetch<Branch>('filiais', {
+        select: 'id,nome,cidade,estado,pais',
+        order: 'nome.asc',
     });
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`Erro ao buscar filiais: ${response.status} ${errorText}`);
-    }
-
-    return response.json() as Promise<Branch[]>;
-};
 
 export const useLocationSelection = (defaultCountry: string = 'Brasil'): UseLocationSelectionReturn => {
     const [selectedCountry, setSelectedCountryState] = useState<string>(defaultCountry);
     const [selectedState, setSelectedStateState] = useState<string>('');
+    const [toastShown, setToastShown] = useState(false);
 
-    // Fetch all branches
-    const { data: allBranches = [], isLoading, error, refetch } = useQuery({
+    const { data: allBranches = [], isLoading, isFetching, error, refetch } = useQuery({
         queryKey: ['all-branches-for-location'],
         queryFn: fetchBranches,
-        staleTime: 60000, // Cache for 1 minute
-        retry: 3,
-        retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
+        staleTime: 5 * 60_000,
+        retry: 6,
+        retryDelay: (attempt) => Math.min(2_000 * 2 ** attempt, 30_000),
+        refetchOnReconnect: true,
+        refetchOnWindowFocus: true,
     });
 
-    // Extract unique countries, ensuring Brasil is first
-    const countries = useMemo(() => {
-        const uniqueCountries = [...new Set(allBranches.map(b => b.pais || 'Brasil'))].sort();
-
-        // Put Brasil first if it exists
-        const brasilIndex = uniqueCountries.indexOf('Brasil');
-        if (brasilIndex > 0) {
-            uniqueCountries.splice(brasilIndex, 1);
-            uniqueCountries.unshift('Brasil');
+    // Toast informativo (não bloqueante) somente após esgotar todas as tentativas
+    useEffect(() => {
+        if (error && !toastShown) {
+            setToastShown(true);
+            toast.warning('Problema ao conectar com o servidor. Tentando novamente...', {
+                duration: 8_000,
+            });
         }
+        if (!error && toastShown) {
+            setToastShown(false);
+        }
+    }, [error, toastShown]);
 
-        console.log('🌍 Countries available:', uniqueCountries);
-        return uniqueCountries;
+    const countries = useMemo(() => {
+        const unique = [...new Set(allBranches.map(b => b.pais || 'Brasil'))].sort();
+        const idx = unique.indexOf('Brasil');
+        if (idx > 0) { unique.splice(idx, 1); unique.unshift('Brasil'); }
+        return unique;
     }, [allBranches]);
 
-    // Get states for selected country
     const states = useMemo(() => {
         if (!selectedCountry) return [];
-
-        const countryBranches = allBranches.filter(b => (b.pais || 'Brasil') === selectedCountry);
-        const uniqueStates = [...new Set(countryBranches.map(b => b.estado))].filter(Boolean).sort();
-
-        console.log(`📍 States for ${selectedCountry}:`, uniqueStates);
-        return uniqueStates;
+        return [...new Set(
+            allBranches.filter(b => (b.pais || 'Brasil') === selectedCountry).map(b => b.estado)
+        )].filter(Boolean).sort() as string[];
     }, [allBranches, selectedCountry]);
 
-    // Get branches for selected state
     const branches = useMemo(() => {
         if (!selectedState) return [];
-
-        const stateBranches = allBranches.filter(
+        return allBranches.filter(
             b => (b.pais || 'Brasil') === selectedCountry && b.estado === selectedState
         );
-
-        console.log(`🏢 Branches for ${selectedState}:`, stateBranches.length);
-        return stateBranches;
     }, [allBranches, selectedCountry, selectedState]);
 
-    // Handlers with state reset
     const setSelectedCountry = useCallback((country: string) => {
-        console.log('🌍 Country selected:', country);
         setSelectedCountryState(country);
-        setSelectedStateState(''); // Reset state when country changes
+        setSelectedStateState('');
     }, []);
 
     const setSelectedState = useCallback((state: string) => {
-        console.log('📍 State selected:', state);
         setSelectedStateState(state);
     }, []);
 
@@ -132,6 +104,7 @@ export const useLocationSelection = (defaultCountry: string = 'Brasil'): UseLoca
         setSelectedCountry,
         setSelectedState,
         isLoading,
+        isFetching,
         error: error as Error | null,
         refetch,
     };

--- a/src/hooks/usePublicEvents.ts
+++ b/src/hooks/usePublicEvents.ts
@@ -1,6 +1,6 @@
 
 import { useQuery } from '@tanstack/react-query';
-import { supabasePublic } from '@/lib/supabase-public';
+import { publicFetch } from '@/lib/api/publicFetch';
 import type { Event } from '@/lib/types/database';
 
 export interface PublicEventsResult {
@@ -12,19 +12,15 @@ export function usePublicEvents() {
   return useQuery<PublicEventsResult>({
     queryKey: ['public-events'],
     queryFn: async () => {
-      const [activeRes, closedRes] = await Promise.all([
-        supabasePublic.from('vw_eventos_publicos_ativos').select('*'),
-        supabasePublic.from('vw_eventos_publicos_encerrados').select('*')
+      const [active, closed] = await Promise.all([
+        publicFetch<Event>('vw_eventos_publicos_ativos', { select: '*' }),
+        publicFetch<Event>('vw_eventos_publicos_encerrados', { select: '*' }),
       ]);
-
-      if (activeRes.error) throw activeRes.error;
-      if (closedRes.error) throw closedRes.error;
-
-      return {
-        active: (activeRes.data || []) as Event[],
-        closed: (closedRes.data || []) as Event[],
-      };
+      return { active, closed };
     },
     staleTime: 60_000,
+    retry: 3,
+    retryDelay: (attempt) => Math.min(2_000 * 2 ** attempt, 15_000),
+    refetchOnReconnect: true,
   });
 }

--- a/src/lib/api/branches.ts
+++ b/src/lib/api/branches.ts
@@ -1,154 +1,39 @@
 
+import { publicFetch } from './publicFetch';
 import { supabase } from '../supabase';
 import type { Branch, BranchAnalytics } from '../../types/api';
 
+// Para usuários autenticados — usa o cliente Supabase com sessão ativa
 export const fetchBranches = async (): Promise<Branch[]> => {
-  console.log('🔍 Fetching branches...');
-  try {
-    // Test connection first
-    console.log('🧪 Testing Supabase connection...');
-    
-    const { data, error } = await supabase
-      .from('filiais')
-      .select('*')
-      .order('nome', { ascending: true });
+  const { data, error } = await supabase
+    .from('filiais')
+    .select('*')
+    .order('nome', { ascending: true });
 
-    if (error) {
-      console.error('❌ Error fetching branches:', {
-        message: error.message,
-        details: error.details,
-        hint: error.hint,
-        code: error.code
-      });
-      throw error;
-    }
-
-    console.log('✅ Raw branches data:', {
-      count: data?.length || 0,
-      sample: data?.[0] || null,
-      allData: data
-    });
-
-    if (!data || data.length === 0) {
-      console.warn('⚠️ No branches found in database');
-      return [];
-    }
-
-    console.log('✅ Branches fetched successfully:', data.length, 'records');
-    return data || [];
-  } catch (error) {
-    console.error('💥 Exception in fetchBranches:', error);
-    throw error;
-  }
+  if (error) throw error;
+  return data || [];
 };
 
+// Agrupa filiais por estado — para usuários autenticados (dashboards, etc.)
 export const fetchBranchesByState = async (): Promise<{ estado: string; branches: Branch[] }[]> => {
-  console.log('🗺️ Fetching branches grouped by state...');
-  
-  try {
-    // First test if table exists and is accessible
-    console.log('🧪 Testing table access...');
-    
-    const { data: branchesData, error: branchesError } = await supabase
-      .from('filiais')
-      .select('*')
-      .order('nome', { ascending: true });
-    
-    if (branchesError) {
-      console.error('❌ Database error:', {
-        code: branchesError.code,
-        message: branchesError.message,
-        details: branchesError.details,
-        hint: branchesError.hint
-      });
-      
-      // Try alternative approach with public API
-      console.log('🔄 Attempting fallback with public API...');
-      try {
-        const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://sb.nova-acropole.org.br';
-        const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'x9Ll0f6bKmCBQWXGrBHtH4zPxEht0Of7XShBxUV8IkJPF8GKjXK4VKeTTt0bAMvbWcF7zUOZA02pdbLahz9Z4eFzhk6EVPwflciK5HasI7Cm7zokA4y3Sg8EG34qseUQZGTUiTjTAf9idr6mcdEEPdKSUvju6PwLJxLRjSF3oRRF6KTHrPyWpyY5rJs7m7QCFd1uMOSBQ7gY4RtTMydqWAgIHJJhxTPxC49A2rMuB0Z';
-        
-        const fallbackUrl = `${supabaseUrl}/rest/v1/filiais?select=*&order=nome.asc`;
-        console.log('🌐 Fallback URL:', fallbackUrl);
-        
-        const publicResponse = await fetch(fallbackUrl, {
-          headers: {
-            'apikey': supabaseAnonKey,
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
-          }
-        });
-        
-        console.log('📡 Fallback response status:', publicResponse.status);
-        
-        if (publicResponse.ok) {
-          const fallbackData = await publicResponse.json() as Branch[];
-          console.log('✅ Fallback data retrieved:', fallbackData.length, 'records');
-          if (fallbackData && fallbackData.length > 0) {
-            // Process fallback data same way
-            const uniqueStates = Array.from(new Set(fallbackData.map((branch: Branch) => branch.estado)))
-              .filter((estado): estado is string => Boolean(estado))
-              .sort();
-            
-            const result = uniqueStates.map(estado => ({
-              estado,
-              branches: fallbackData.filter((branch: Branch) => branch.estado === estado) || []
-            }));
-            
-            console.log('✅ Fallback result processed:', result.length, 'states');
-            return result;
-          }
-        }
-      } catch (fallbackError) {
-        console.error('❌ Fallback also failed:', fallbackError);
-      }
-      
-      throw branchesError;
-    }
+  const { data, error } = await supabase
+    .from('filiais')
+    .select('*')
+    .order('nome', { ascending: true });
 
-    console.log('📊 Raw data analysis:', {
-      totalRecords: branchesData?.length || 0,
-      hasData: !!branchesData && branchesData.length > 0,
-      sampleRecord: branchesData?.[0],
-      stateField: branchesData?.[0]?.estado,
-      uniqueStates: branchesData ? [...new Set(branchesData.map(b => b.estado))].filter(Boolean) : []
-    });
+  if (error) throw error;
+  if (!data || data.length === 0) return [];
 
-    if (!branchesData || branchesData.length === 0) {
-      console.warn('⚠️ No branches data returned from database');
-      return [];
-    }
+  const uniqueStates = [...new Set(data.map(b => b.estado))]
+    .filter((s): s is string => Boolean(s))
+    .sort();
 
-    // Extract unique states and sort them
-    const uniqueStates = Array.from(new Set(branchesData.map(branch => branch.estado)))
-      .filter((estado): estado is string => Boolean(estado))
-      .sort();
-    
-    console.log('🗺️ States found:', uniqueStates);
-    
-    // Group branches by state
-    const result = uniqueStates.map(estado => {
-      const stateBranches = branchesData.filter(branch => branch.estado === estado);
-      console.log(`📍 State ${estado}: ${stateBranches.length} branches`);
-      return {
-        estado,
-        branches: stateBranches || []
-      };
-    });
-    
-    console.log('✅ Final grouped result:', {
-      statesCount: result.length,
-      totalBranches: result.reduce((sum, state) => sum + state.branches.length, 0),
-      statesSummary: result.map(s => ({ state: s.estado, count: s.branches.length }))
-    });
-    
-    return result;
-  } catch (error: any) {
-    console.error('💥 Critical error in fetchBranchesByState:', {
-      message: error.message,
-      stack: error.stack,
-      name: error.name
-    });
-    throw error;
-  }
+  return uniqueStates.map(estado => ({
+    estado,
+    branches: data.filter(b => b.estado === estado),
+  }));
 };
+
+// Para contextos públicos (cadastro, landing page) — sem sessão, sem JWT
+export const fetchBranchesPublic = (): Promise<Branch[]> =>
+  publicFetch<Branch>('filiais', { select: '*', order: 'nome.asc' });

--- a/src/lib/api/publicFetch.ts
+++ b/src/lib/api/publicFetch.ts
@@ -1,0 +1,50 @@
+/**
+ * Utilitário para chamadas públicas ao servidor Supabase self-hosted.
+ *
+ * O servidor usa uma chave anon que não é JWT padrão. O cliente Supabase JS
+ * envia Authorization: Bearer <chave>, que o PostgREST rejeita ao tentar
+ * validar como JWT (PGRST301 - Expected 3 parts; got 1).
+ *
+ * A solução correta para este servidor é usar apenas o header `apikey`
+ * (sem Authorization), que o servidor aceita sem validação JWT.
+ *
+ * Use esta função para qualquer dado publicamente acessível (sem login),
+ * como filiais, eventos públicos, etc.
+ */
+
+const SUPABASE_URL = (import.meta.env.VITE_SUPABASE_URL || '').replace(/\/$/, '');
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+/**
+ * Busca dados de uma tabela/view pública do Supabase via REST.
+ * Não envia Authorization header — só apikey quando disponível.
+ */
+export async function publicFetch<T>(
+  path: string,
+  params?: Record<string, string>
+): Promise<T[]> {
+  if (!SUPABASE_URL) {
+    throw new Error('VITE_SUPABASE_URL não está configurada no ambiente de build.');
+  }
+
+  const qs = params ? `?${new URLSearchParams(params)}` : '';
+  const url = `${SUPABASE_URL}/rest/v1/${path}${qs}`;
+
+  const headers: HeadersInit = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+  };
+
+  if (SUPABASE_ANON_KEY) {
+    headers['apikey'] = SUPABASE_ANON_KEY;
+  }
+
+  const response = await fetch(url, { headers });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Erro ao buscar ${path}: HTTP ${response.status} ${body}`);
+  }
+
+  return response.json() as Promise<T[]>;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,15 @@ const getBuildTime = () => {
   return new Date().toISOString();
 };
 
+// Avisar em tempo de build se variáveis críticas não estiverem configuradas
+if (!process.env.VITE_SUPABASE_URL || !process.env.VITE_SUPABASE_ANON_KEY) {
+  console.warn(
+    '\n⚠️  ATENÇÃO: VITE_SUPABASE_URL ou VITE_SUPABASE_ANON_KEY não estão definidas no ambiente de build.\n' +
+    '   Chamadas públicas ao Supabase (filiais, eventos) vão falhar em produção.\n' +
+    '   Verifique o arquivo .env ou as variáveis de ambiente do servidor de deploy.\n'
+  );
+}
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   server: {


### PR DESCRIPTION
## Problema

A busca de filiais (cadastro) e eventos públicos (landing page) falhava porque o servidor self-hosted usa uma chave anon que não é JWT. O cliente Supabase JS envia `Authorization: Bearer <chave>` que o PostgREST rejeita com `PGRST301 Expected 3 parts; got 1`. O formulário mostrava `BranchSelectionError` e o usuário não conseguia se cadastrar.

## Solução

### 1. `src/lib/api/publicFetch.ts` (NOVO)
Utilitário centralizado para todas as chamadas públicas. Envia apenas `apikey` header (sem `Authorization: Bearer`). 100% dinâmico via env vars — nenhum dado hardcoded.

### 2. `useLocationSelection.ts`
- Usa `publicFetch` (sem cliente Supabase)
- Retry 6x com backoff exponencial (até 30s de delay)
- `refetchOnReconnect` e `refetchOnWindowFocus` ativos
- Toast informativo (não bloqueante) em caso de falha persistente

### 3. `LocationSelector.tsx`
- **Remove `BranchSelectionError`** — usuário nunca vê tela de erro
- Campos em skeleton enquanto retries acontecem em background
- Formulário nunca bloqueia

### 4. `usePublicEvents.ts`
- Substitui `supabasePublic` (com JWT) por `publicFetch`
- Mesmo problema, mesma correção

### 5. `branches.ts`
- Remove padrão duplo (cliente Supabase + fallback)
- Expõe `fetchBranchesPublic()` para contextos sem autenticação

### 6. `vite.config.ts`
- Aviso no build se `VITE_SUPABASE_ANON_KEY` não estiver configurada