### PR TITLE
fix: skeleton e retry automatico quando servidor fora do ar

### DIFF
--- a/src/components/auth/form-sections/location/LocationSelector.tsx
+++ b/src/components/auth/form-sections/location/LocationSelector.tsx
@@ -26,8 +26,9 @@ export const LocationSelector = ({ form, disabled = false, context = 'default' }
     isFetching,
   } = useLocationSelection('Brasil');
 
-  // Considera loading enquanto a query inicial ou qualquer retry estiver em andamento
-  const loading = isLoading || isFetching;
+  // Mantém skeleton enquanto carregando, retentando, OU em erro (servidor fora do ar).
+  // Campos em branco sem opções confundem o usuário — skeleton + toast é mais claro.
+  const loading = isLoading || isFetching || !!error;
 
   useEffect(() => {
     if (selectedCountry) {

--- a/src/hooks/useLocationSelection.ts
+++ b/src/hooks/useLocationSelection.ts
@@ -50,6 +50,10 @@ export const useLocationSelection = (defaultCountry: string = 'Brasil'): UseLoca
         retryDelay: (attempt) => Math.min(2_000 * 2 ** attempt, 30_000),
         refetchOnReconnect: true,
         refetchOnWindowFocus: true,
+        // Quando em erro (servidor fora do ar), retenta a cada 30s automaticamente.
+        // Quando o servidor voltar, os campos carregam sem precisar de atualização manual.
+        refetchInterval: (query) => (query.state.status === 'error' ? 30_000 : false),
+        refetchIntervalInBackground: false,
     });
 
     // Toast informativo (não bloqueante) somente após esgotar todas as tentativas


### PR DESCRIPTION
## Problema

Quando o servidor Supabase está fora do ar, após os 6 retries iniciais falharem os campos País/Estado/Sede mostravam selects **vazios** (sem opções, sem explicação). O usuário via campos em branco sem entender o que estava acontecendo.

## Correções

### 1. Skeleton enquanto em erro
`LocationSelector`: `loading = isLoading || isFetching || !!error`

Enquanto o servidor estiver fora do ar, os campos ficam em skeleton (cinza) + toast informativo. Muito melhor que campos em branco.

### 2. Retry automático a cada 30s
`useLocationSelection`: adicionado `refetchInterval: 30_000` quando em estado de erro.

**Quando o servidor voltar**, os campos carregam automaticamente sem o usuário precisar atualizar a página manualmente.