### PR TITLE
fix: politica RLS de INSERT/UPDATE/DELETE para filiais

### DIFF
--- a/src/components/auth/form-sections/location/LocationSelector.tsx
+++ b/src/components/auth/form-sections/location/LocationSelector.tsx
@@ -26,8 +26,9 @@ export const LocationSelector = ({ form, disabled = false, context = 'default' }
     isFetching,
   } = useLocationSelection('Brasil');
 
-  // Considera loading enquanto a query inicial ou qualquer retry estiver em andamento
-  const loading = isLoading || isFetching;
+  // Mantém skeleton enquanto carregando, retentando, OU em erro (servidor fora do ar).
+  // Campos em branco sem opções confundem o usuário — skeleton + toast é mais claro.
+  const loading = isLoading || isFetching || !!error;
 
   useEffect(() => {
     if (selectedCountry) {

--- a/src/components/event-management/event-branches/useEventBranches.ts
+++ b/src/components/event-management/event-branches/useEventBranches.ts
@@ -122,23 +122,23 @@ export function useEventBranches(eventId: string | null) {
     try {
       const { data: newBranch, error } = await supabase
         .from('filiais')
-        .insert([data])
+        .insert([{ ...data, pais: 'Brasil' }])
         .select()
         .single();
-      
+
       if (error) throw error;
-      
-      // Add the new branch to the local state
+
       setBranches(prev => [...prev, { ...newBranch, is_linked: false }]);
-      
       toast.success('Filial criada com sucesso!');
       return newBranch;
     } catch (error: any) {
-      console.error('Error creating branch:', error);
+      console.error('Error creating branch:', error?.message, '| code:', error?.code, '| details:', error?.details);
       if (error.code === '23505') {
         toast.error('Já existe uma filial com este nome');
+      } else if (error.code === '42501' || error?.message?.includes('row-level security')) {
+        toast.error('Sem permissão para criar filial. Contate o administrador do sistema.');
       } else {
-        toast.error('Erro ao criar filial');
+        toast.error(`Erro ao criar filial: ${error?.message || 'erro desconhecido'}`);
       }
       throw error;
     } finally {

--- a/src/hooks/useLocationSelection.ts
+++ b/src/hooks/useLocationSelection.ts
@@ -50,6 +50,10 @@ export const useLocationSelection = (defaultCountry: string = 'Brasil'): UseLoca
         retryDelay: (attempt) => Math.min(2_000 * 2 ** attempt, 30_000),
         refetchOnReconnect: true,
         refetchOnWindowFocus: true,
+        // Quando em erro (servidor fora do ar), retenta a cada 30s automaticamente.
+        // Quando o servidor voltar, os campos carregam sem precisar de atualização manual.
+        refetchInterval: (query) => (query.state.status === 'error' ? 30_000 : false),
+        refetchIntervalInBackground: false,
     });
 
     // Toast informativo (não bloqueante) somente após esgotar todas as tentativas

--- a/supabase/migrations/20260623_fix_filiais_insert_policy.sql
+++ b/supabase/migrations/20260623_fix_filiais_insert_policy.sql
@@ -1,0 +1,78 @@
+-- CORREÇÃO: Políticas de INSERT/UPDATE/DELETE para a tabela filiais
+--
+-- Problema: as migrações anteriores (fix_filiais_permissions, force_open_filiais)
+-- criaram apenas a política de SELECT (leitura pública para anon/authenticated).
+-- Com RLS ativo e sem política de INSERT, toda tentativa de criar uma nova
+-- filial era bloqueada pelo PostgreSQL com erro de RLS.
+--
+-- Solução: adicionar políticas para operações de escrita, permitindo apenas
+-- usuários com cadastra_eventos = true (admins/mestres que gerenciam eventos).
+
+BEGIN;
+
+-- Remover políticas de escrita antigas se existirem
+DROP POLICY IF EXISTS "Admins can insert filiais" ON public.filiais;
+DROP POLICY IF EXISTS "Admins can update filiais" ON public.filiais;
+DROP POLICY IF EXISTS "Admins can delete filiais" ON public.filiais;
+DROP POLICY IF EXISTS "filiais_insert_admins" ON public.filiais;
+DROP POLICY IF EXISTS "filiais_update_admins" ON public.filiais;
+DROP POLICY IF EXISTS "filiais_delete_admins" ON public.filiais;
+
+-- Política de INSERT: apenas usuários com cadastra_eventos = true
+CREATE POLICY "filiais_insert_admins"
+ON public.filiais
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.usuarios u
+    WHERE u.id = auth.uid()
+    AND u.cadastra_eventos = true
+  )
+);
+
+-- Política de UPDATE: apenas usuários com cadastra_eventos = true
+CREATE POLICY "filiais_update_admins"
+ON public.filiais
+FOR UPDATE
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.usuarios u
+    WHERE u.id = auth.uid()
+    AND u.cadastra_eventos = true
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.usuarios u
+    WHERE u.id = auth.uid()
+    AND u.cadastra_eventos = true
+  )
+);
+
+-- Política de DELETE: apenas usuários com cadastra_eventos = true
+CREATE POLICY "filiais_delete_admins"
+ON public.filiais
+FOR DELETE
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.usuarios u
+    WHERE u.id = auth.uid()
+    AND u.cadastra_eventos = true
+  )
+);
+
+-- Garantir GRANTs de escrita para authenticated (além do SELECT já concedido)
+GRANT INSERT, UPDATE, DELETE ON public.filiais TO authenticated;
+
+COMMIT;
+
+SELECT 'Políticas de INSERT/UPDATE/DELETE para filiais configuradas com sucesso.' AS status;
+
+-- Verificar políticas ativas
+SELECT policyname, cmd, roles
+FROM pg_policies
+WHERE tablename = 'filiais' AND schemaname = 'public'
+ORDER BY cmd;


### PR DESCRIPTION
## Causa raiz

As migrações `fix_filiais_permissions` e `force_open_filiais` criaram **apenas** `FOR SELECT`. Com RLS ativo na tabela, INSERT era bloqueado pelo PostgreSQL com erro 42501 (row-level security violation). O código capturava o erro mas mostrava apenas 'Erro ao criar filial' sem detalhe.

## Correções

### 1. Migração SQL `20260623_fix_filiais_insert_policy.sql`
**⚠️ Precisa ser executada no Supabase SQL Editor de produção**

Adiciona as políticas:
- `filiais_insert_admins` — permite INSERT para `usuarios.cadastra_eventos = true`
- `filiais_update_admins` — idem para UPDATE
- `filiais_delete_admins` — idem para DELETE
- GRANT INSERT/UPDATE/DELETE para `authenticated`

### 2. `createBranch` em `useEventBranches.ts`
- Inclui `pais: 'Brasil'` no insert (coluna existe no DB mas não nos tipos TS)
- Erro 42501 mostra mensagem específica: 'Sem permissão para criar filial'
- Log de console com `message`, `code` e `details` para debug futuro