### PR TITLE
fix: ReferenceError tela branca no cadastro (error nao desestruturado)

### DIFF
--- a/src/components/auth/form-sections/location/LocationSelector.tsx
+++ b/src/components/auth/form-sections/location/LocationSelector.tsx
@@ -24,6 +24,7 @@ export const LocationSelector = ({ form, disabled = false, context = 'default' }
     setSelectedState,
     isLoading,
     isFetching,
+    error,
   } = useLocationSelection('Brasil');
 
   // Mantém skeleton enquanto carregando, retentando, OU em erro (servidor fora do ar).


### PR DESCRIPTION
## Bug

Introduzido no PR #38: adicionei `|| !!error` no cálculo de `loading` em `LocationSelector.tsx` mas esqueci de incluir `error` na desestruturação do hook `useLocationSelection`.

Resultado em produção: `ReferenceError: error is not defined` durante o render → tela em branco ao abrir 'Cadastre-se'.

## Fix

Adicionar `error` à desestruturação do hook. Uma linha.