### PR TITLE
feat: 7 correções — Chamadas, Cronograma, Frequência e Atletas

### DIFF
--- a/src/components/AthleteRegistrationCard.tsx
+++ b/src/components/AthleteRegistrationCard.tsx
@@ -26,6 +26,8 @@ interface AthleteRegistrationCardProps {
   readOnly?: boolean;
   eventId?: string;
   enrollmentType?: EnrollmentType;
+  dialogOpen?: boolean;
+  onDialogOpenChange?: (open: boolean) => void;
 }
 
 export function AthleteRegistrationCard({
@@ -35,9 +37,13 @@ export function AthleteRegistrationCard({
   isCurrentUser,
   readOnly = false,
   eventId,
-  enrollmentType
+  enrollmentType,
+  dialogOpen,
+  onDialogOpenChange,
 }: AthleteRegistrationCardProps) {
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [_internalOpen, _setInternalOpen] = useState(false);
+  const isDialogOpen = dialogOpen !== undefined ? dialogOpen : _internalOpen;
+  const setIsDialogOpen = onDialogOpenChange ?? _setInternalOpen;
   const [isEnrollDialogOpen, setIsEnrollDialogOpen] = useState(false);
   const { user, currentEventId } = useAuth();
 

--- a/src/components/athlete-card/ModalitiesTable.tsx
+++ b/src/components/athlete-card/ModalitiesTable.tsx
@@ -88,11 +88,11 @@ export const ModalitiesTable: React.FC<ModalitiesTableProps> = ({
               <Select
                 value={modalityStatuses[modalidade.id] || modalidade.status}
                 onValueChange={(value) => onStatusChange(modalidade.id, value)}
-                disabled={!!readOnly || !justifications[modalidade.id] || isUpdating[modalidade.id]}
+                disabled={!!readOnly || isUpdating[modalidade.id]}
               >
                 <SelectTrigger className={cn(
                   "w-[180px]",
-                  ((!!readOnly) || !justifications[modalidade.id] || isUpdating[modalidade.id]) && "opacity-50 cursor-not-allowed"
+                  (!!readOnly || isUpdating[modalidade.id]) && "opacity-50 cursor-not-allowed"
                 )}>
                   <SelectValue placeholder="Selecione o status" />
                 </SelectTrigger>

--- a/src/components/athlete-card/hooks/useModalityHandlers.ts
+++ b/src/components/athlete-card/hooks/useModalityHandlers.ts
@@ -1,9 +1,12 @@
 
 import { useState } from 'react';
+import { toast } from 'sonner';
 
 interface UseModalityHandlersProps {
   onStatusChange: (modalityId: string, status: string, justification: string) => Promise<void>;
 }
+
+const REQUIRES_JUSTIFICATION = ['pendente', 'cancelado'];
 
 export const useModalityHandlers = ({ onStatusChange }: UseModalityHandlersProps) => {
   const [justifications, setJustifications] = useState<Record<string, string>>({});
@@ -19,13 +22,19 @@ export const useModalityHandlers = ({ onStatusChange }: UseModalityHandlersProps
 
   const handleStatusChange = async (modalityId: string, status: string) => {
     const justification = justifications[modalityId] || '';
-    
+
+    if (REQUIRES_JUSTIFICATION.includes(status) && !justification.trim()) {
+      toast.error('Justificativa obrigatória para alterações para pendente ou cancelado.');
+      return;
+    }
+
     setIsUpdating(prev => ({ ...prev, [modalityId]: true }));
     setModalityStatuses(prev => ({ ...prev, [modalityId]: status }));
-    
+
     try {
       await onStatusChange(modalityId, status, justification);
     } catch (error) {
+      setModalityStatuses(prev => ({ ...prev, [modalityId]: '' }));
       console.error('Error updating status:', error);
     } finally {
       setIsUpdating(prev => ({ ...prev, [modalityId]: false }));

--- a/src/components/athlete-card/utils/statusColors.ts
+++ b/src/components/athlete-card/utils/statusColors.ts
@@ -1,0 +1,25 @@
+export function getStatusBadgeStyle(status: string): string {
+  switch (status) {
+    case 'confirmado':
+      return 'bg-success-background text-success-foreground border-success/20';
+    case 'pendente':
+      return 'bg-warning-background text-warning-foreground border-warning/20';
+    case 'cancelado':
+      return 'bg-destructive/10 text-destructive-foreground border-destructive/20';
+    default:
+      return 'bg-neutral-background text-neutral-foreground border-neutral/20';
+  }
+}
+
+export function getStatusBorderColor(status: string): string {
+  switch (status) {
+    case 'confirmado':
+      return 'border-l-4 border-l-success bg-success-background/50';
+    case 'pendente':
+      return 'border-l-4 border-l-warning bg-warning-background/50';
+    case 'cancelado':
+      return 'border-l-4 border-l-destructive bg-destructive/5';
+    default:
+      return 'border-l-4 border-l-neutral bg-neutral-background/50';
+  }
+}

--- a/src/components/dashboard/AthleteTable.tsx
+++ b/src/components/dashboard/AthleteTable.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { AthleteManagement } from '@/lib/api';
+import { AthleteRegistrationCard } from '@/components/AthleteRegistrationCard';
+import { getStatusBadgeStyle } from '@/components/athlete-card/utils/statusColors';
+import { EnrollmentType } from '@/hooks/useEnrollAthleteInModality';
+
+interface AthleteTableProps {
+  athletes: AthleteManagement[];
+  onStatusChange: (modalityId: string, status: string, justification: string) => Promise<void>;
+  onPaymentStatusChange?: (athleteId: string, status: string) => Promise<void>;
+  currentUserId?: string;
+  eventId?: string;
+  enrollmentType?: EnrollmentType;
+  readOnly?: boolean;
+}
+
+export function AthleteTable({
+  athletes,
+  onStatusChange,
+  onPaymentStatusChange,
+  currentUserId,
+  eventId,
+  enrollmentType,
+  readOnly,
+}: AthleteTableProps) {
+  const [selectedAthleteId, setSelectedAthleteId] = useState<string | null>(null);
+
+  if (athletes.length === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        Nenhum atleta encontrado com os filtros selecionados.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="rounded-xl border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-muted/40">
+              <TableHead className="font-semibold">Nome</TableHead>
+              <TableHead className="font-semibold">Pagamento</TableHead>
+              <TableHead className="font-semibold">Modalidades</TableHead>
+              <TableHead className="font-semibold">Filial</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {athletes.map((athlete) => {
+              const isCurrentUser = athlete.id === currentUserId;
+              return (
+                <TableRow
+                  key={athlete.id}
+                  className={cn(
+                    'cursor-pointer transition-colors hover:bg-muted/40',
+                    isCurrentUser && 'bg-olimpics-green-primary/5',
+                  )}
+                  onClick={() => setSelectedAthleteId(athlete.id)}
+                >
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-sm">{athlete.nome_atleta}</span>
+                      {isCurrentUser && (
+                        <Badge className="text-[10px] px-1.5 py-0 bg-olimpics-green-primary/10 text-olimpics-green-primary border-olimpics-green-primary/20">
+                          Eu
+                        </Badge>
+                      )}
+                      {athlete.numero_identificador && (
+                        <span className="text-xs text-muted-foreground">#{athlete.numero_identificador}</span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge className={cn('capitalize text-xs', getStatusBadgeStyle(athlete.status_pagamento))}>
+                      {athlete.status_pagamento}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {athlete.modalidades.slice(0, 3).map((mod) => (
+                        <Badge
+                          key={mod.id}
+                          variant="outline"
+                          className={cn('text-[10px] px-1.5 py-0', getStatusBadgeStyle(mod.status))}
+                        >
+                          {mod.modalidade}
+                        </Badge>
+                      ))}
+                      {athlete.modalidades.length > 3 && (
+                        <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                          +{athlete.modalidades.length - 3}
+                        </Badge>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {athlete.filial_nome}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Dialog de detalhe — reutiliza AthleteRegistrationCard com controle externo */}
+      {selectedAthleteId && (() => {
+        const athlete = athletes.find(a => a.id === selectedAthleteId)!;
+        return (
+          <AthleteRegistrationCard
+            key={athlete.id}
+            registration={athlete}
+            onStatusChange={onStatusChange}
+            onPaymentStatusChange={onPaymentStatusChange}
+            isCurrentUser={athlete.id === currentUserId}
+            readOnly={readOnly}
+            eventId={eventId}
+            enrollmentType={enrollmentType}
+            dialogOpen={true}
+            onDialogOpenChange={(open) => { if (!open) setSelectedAthleteId(null); }}
+          />
+        );
+      })()}
+    </>
+  );
+}

--- a/src/components/dashboard/PaginatedAthleteList.tsx
+++ b/src/components/dashboard/PaginatedAthleteList.tsx
@@ -1,5 +1,6 @@
 
 import { AthleteRegistrationCard } from "@/components/AthleteRegistrationCard";
+import { AthleteTable } from "@/components/dashboard/AthleteTable";
 import {
   Pagination,
   PaginationContent,
@@ -9,11 +10,15 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
+import { Button } from "@/components/ui/button";
 import { AthleteManagement } from "@/lib/api";
 import { useState, useEffect, useMemo } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useReadOnlyEvent } from "@/hooks/useReadOnlyEvent";
 import { EnrollmentType } from "@/hooks/useEnrollAthleteInModality";
+import { LayoutGrid, Table2 } from "lucide-react";
+
+type ViewMode = 'cards' | 'table';
 
 interface PaginatedAthleteListProps {
   athletes: AthleteManagement[];
@@ -37,6 +42,7 @@ export function PaginatedAthleteList({
   enrollmentType
 }: PaginatedAthleteListProps) {
   const [currentPage, setCurrentPage] = useState(1);
+  const [viewMode, setViewMode] = useState<ViewMode>('cards');
   const { user, currentEventId } = useAuth();
   const { data: readOnlyData } = useReadOnlyEvent(user?.id, currentEventId);
   const isReadOnly = !!readOnlyData?.isReadOnly;
@@ -51,14 +57,6 @@ export function PaginatedAthleteList({
     if (!delegationOnly || !user?.filial_id) {
       return athletes;
     }
-    
-    // Log for debugging
-    console.log('Filtering athletes for delegation view', {
-      userBranchId: user.filial_id,
-      totalAthletes: athletes.length,
-      athleteBranches: athletes.map(a => a.filial_id)
-    });
-    
     return athletes.filter(athlete => athlete.filial_id === user.filial_id);
   }, [athletes, delegationOnly, user?.filial_id]);
 
@@ -106,7 +104,7 @@ export function PaginatedAthleteList({
   if (filteredAthletes.length === 0) {
     return (
       <div className="text-center py-8 text-muted-foreground">
-        {delegationOnly 
+        {delegationOnly
           ? "Nenhum atleta encontrado na sua delegação com os filtros selecionados."
           : "Nenhum atleta encontrado com os filtros selecionados."}
       </div>
@@ -114,67 +112,112 @@ export function PaginatedAthleteList({
   }
 
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {currentAthletes.map((athlete) => (
-          <AthleteRegistrationCard
-            key={athlete.id}
-            registration={athlete}
-            onStatusChange={onStatusChange}
-            onPaymentStatusChange={onPaymentStatusChange}
-            isCurrentUser={currentUserId === athlete.id}
-            readOnly={isReadOnly}
-            eventId={effectiveEventId || undefined}
-            enrollmentType={enrollmentType}
-          />
-        ))}
+    <div className="space-y-4">
+      {/* Toggle de visualização */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {filteredAthletes.length} atleta{filteredAthletes.length !== 1 ? 's' : ''} encontrado{filteredAthletes.length !== 1 ? 's' : ''}
+        </p>
+        <div className="flex items-center gap-1 rounded-lg border p-1 bg-muted/30">
+          <Button
+            variant={viewMode === 'cards' ? 'default' : 'ghost'}
+            size="sm"
+            className="h-7 px-2.5"
+            onClick={() => setViewMode('cards')}
+            title="Visualização em cards"
+          >
+            <LayoutGrid className="h-4 w-4" />
+          </Button>
+          <Button
+            variant={viewMode === 'table' ? 'default' : 'ghost'}
+            size="sm"
+            className="h-7 px-2.5"
+            onClick={() => setViewMode('table')}
+            title="Visualização em tabela"
+          >
+            <Table2 className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
 
-      {totalPages > 1 && (
-        <div className="flex justify-center mt-6">
-          <Pagination>
-            <PaginationContent>
-              <PaginationItem>
-                <PaginationPrevious
-                  onClick={() => handlePageChange(currentPage - 1)}
-                  className={currentPage === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"}
-                  aria-disabled={currentPage === 1}
-                />
-              </PaginationItem>
+      {/* Visualização em cards (paginada) */}
+      {viewMode === 'cards' && (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {currentAthletes.map((athlete) => (
+              <AthleteRegistrationCard
+                key={athlete.id}
+                registration={athlete}
+                onStatusChange={onStatusChange}
+                onPaymentStatusChange={onPaymentStatusChange}
+                isCurrentUser={currentUserId === athlete.id}
+                readOnly={isReadOnly}
+                eventId={effectiveEventId || undefined}
+                enrollmentType={enrollmentType}
+              />
+            ))}
+          </div>
 
-              {getPageNumbers().map((pageNum, idx) => (
-                pageNum === -1 ? (
-                  <PaginationItem key={`ellipsis-${idx}`}>
-                    <PaginationEllipsis />
+          {totalPages > 1 && (
+            <div className="flex justify-center mt-6">
+              <Pagination>
+                <PaginationContent>
+                  <PaginationItem>
+                    <PaginationPrevious
+                      onClick={() => handlePageChange(currentPage - 1)}
+                      className={currentPage === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                      aria-disabled={currentPage === 1}
+                    />
                   </PaginationItem>
-                ) : (
-                  <PaginationItem key={pageNum}>
-                    <PaginationLink
-                      onClick={() => handlePageChange(pageNum)}
-                      isActive={pageNum === currentPage}
-                      className="cursor-pointer"
-                    >
-                      {pageNum}
-                    </PaginationLink>
-                  </PaginationItem>
-                )
-              ))}
 
-              <PaginationItem>
-                <PaginationNext
-                  onClick={() => handlePageChange(currentPage + 1)}
-                  className={currentPage === totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
-                  aria-disabled={currentPage === totalPages}
-                />
-              </PaginationItem>
-            </PaginationContent>
-          </Pagination>
-        </div>
+                  {getPageNumbers().map((pageNum, idx) => (
+                    pageNum === -1 ? (
+                      <PaginationItem key={`ellipsis-${idx}`}>
+                        <PaginationEllipsis />
+                      </PaginationItem>
+                    ) : (
+                      <PaginationItem key={pageNum}>
+                        <PaginationLink
+                          onClick={() => handlePageChange(pageNum)}
+                          isActive={pageNum === currentPage}
+                          className="cursor-pointer"
+                        >
+                          {pageNum}
+                        </PaginationLink>
+                      </PaginationItem>
+                    )
+                  ))}
+
+                  <PaginationItem>
+                    <PaginationNext
+                      onClick={() => handlePageChange(currentPage + 1)}
+                      className={currentPage === totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                      aria-disabled={currentPage === totalPages}
+                    />
+                  </PaginationItem>
+                </PaginationContent>
+              </Pagination>
+            </div>
+          )}
+
+          <div className="text-center text-sm text-muted-foreground">
+            Mostrando {startIndex + 1}–{Math.min(endIndex, filteredAthletes.length)} de {filteredAthletes.length} atletas
+          </div>
+        </>
       )}
 
-      <div className="text-center text-sm text-muted-foreground">
-        Mostrando {filteredAthletes.length > 0 ? startIndex + 1 : 0}-{Math.min(endIndex, filteredAthletes.length)} de {filteredAthletes.length} atletas
-      </div>
+      {/* Visualização em tabela (todos os atletas filtrados, sem paginação) */}
+      {viewMode === 'table' && (
+        <AthleteTable
+          athletes={filteredAthletes}
+          onStatusChange={onStatusChange}
+          onPaymentStatusChange={onPaymentStatusChange}
+          currentUserId={currentUserId}
+          eventId={effectiveEventId || undefined}
+          enrollmentType={enrollmentType}
+          readOnly={isReadOnly}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/monitor/AttendanceCreationDialog.tsx
+++ b/src/components/monitor/AttendanceCreationDialog.tsx
@@ -62,7 +62,7 @@ export default function AttendanceCreationDialog({
     }
   }, [open]);
 
-  // Inicializa todos como presentes
+  // Inicializa todos como ausentes — monitor marca apenas quem veio
   useEffect(() => {
     if (athletes && open) {
       setAthletesAttendance(athletes.map(athlete => ({
@@ -70,7 +70,7 @@ export default function AttendanceCreationDialog({
         nome_completo: athlete.nome_completo,
         email: athlete.email,
         numero_identificador: athlete.numero_identificador,
-        status: 'presente' as const
+        status: 'ausente' as const
       })));
     }
   }, [athletes, open]);

--- a/src/components/monitor/MonitorAttendancePage.tsx
+++ b/src/components/monitor/MonitorAttendancePage.tsx
@@ -6,6 +6,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Plus, Calendar, Clock, ChevronRight, AlertTriangle } from "lucide-react";
 import { useMonitorModalities } from "@/hooks/useMonitorModalities";
 import { useAllMonitorSessions } from "@/hooks/useAllMonitorSessions";
+import { useEventSessions } from "@/hooks/useEventSessions";
+import { useUserRoleCheck } from "@/hooks/useUserRoleCheck";
+import { useAuth } from "@/contexts/AuthContext";
 import { MonitorSession } from "@/hooks/useMonitorSessions";
 import { LoadingImage } from "@/components/ui/loading-image";
 import AttendanceCreationDialog from './AttendanceCreationDialog';
@@ -99,8 +102,15 @@ export default function MonitorAttendancePage() {
   const [sessionToEdit, setSessionToEdit] = useState<MonitorSession | null>(null);
   const [detailSessionId, setDetailSessionId] = useState<string | null>(null);
 
+  const { user, currentEventId } = useAuth();
+  const { isOrganizer } = useUserRoleCheck(user?.id ?? '', currentEventId ?? '');
+
   const { data: modalities, isLoading: modalitiesLoading } = useMonitorModalities();
-  const { data: allSessions, isLoading: sessionsLoading } = useAllMonitorSessions();
+  const { data: monitorSessions, isLoading: monitorSessionsLoading } = useAllMonitorSessions();
+  const { data: eventSessions, isLoading: eventSessionsLoading } = useEventSessions();
+
+  const sessionsLoading = isOrganizer ? eventSessionsLoading : monitorSessionsLoading;
+  const rawSessions = isOrganizer ? (eventSessions ?? []) : (monitorSessions ?? []);
 
   /* ── detail view ── */
   if (detailSessionId) {
@@ -121,9 +131,10 @@ export default function MonitorAttendancePage() {
     );
   }
 
-  /* ── no modalities ── */
   const validModalities = (modalities ?? []).filter(m => m.modalidades?.nome);
-  if (validModalities.length === 0) {
+
+  /* ── no modalities (only block for non-organizers) ── */
+  if (!isOrganizer && validModalities.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-center">
         <Calendar className="h-12 w-12 text-muted-foreground/40 mb-4" />
@@ -135,15 +146,14 @@ export default function MonitorAttendancePage() {
     );
   }
 
-  /* ── selected modality for dialog ── */
+  /* ── selected modality for dialog (only relevant if user is also a monitor) ── */
   const selectedMod = modFiltro !== "all"
     ? validModalities.find(m => m.id === modFiltro)
     : validModalities[0];
 
   /* ── filter sessions ── */
-  const sessions = (allSessions ?? []).filter(s => {
+  const sessions = rawSessions.filter(s => {
     if (modFiltro === "all") return true;
-    // match by modality name
     return validModalities.find(
       m => m.id === modFiltro &&
         m.modalidades.nome === s.modalidade_representantes.modalidades.nome
@@ -169,16 +179,18 @@ export default function MonitorAttendancePage() {
           </Select>
         )}
 
-        <div className="sm:ml-auto">
-          <Button
-            onClick={() => setShowCreate(true)}
-            className="bg-olimpics-green-primary hover:bg-olimpics-green-secondary w-full sm:w-auto"
-            size="sm"
-          >
-            <Plus className="h-4 w-4 mr-2" />
-            Nova Chamada
-          </Button>
-        </div>
+        {validModalities.length > 0 && (
+          <div className="sm:ml-auto">
+            <Button
+              onClick={() => setShowCreate(true)}
+              className="bg-olimpics-green-primary hover:bg-olimpics-green-secondary w-full sm:w-auto"
+              size="sm"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Nova Chamada
+            </Button>
+          </div>
+        )}
       </div>
 
       {/* Session list */}
@@ -188,17 +200,19 @@ export default function MonitorAttendancePage() {
           <p className="text-sm font-medium text-foreground">Nenhuma chamada ainda</p>
           <p className="text-xs text-muted-foreground mt-1 mb-4">
             {modFiltro === "all"
-              ? "Crie a primeira chamada para começar a registrar presenças."
+              ? "Nenhuma chamada registrada neste evento ainda."
               : "Não há chamadas para esta modalidade."}
           </p>
-          <Button
-            size="sm"
-            onClick={() => setShowCreate(true)}
-            className="bg-olimpics-green-primary hover:bg-olimpics-green-secondary"
-          >
-            <Plus className="h-4 w-4 mr-1.5" />
-            Criar Chamada
-          </Button>
+          {validModalities.length > 0 && (
+            <Button
+              size="sm"
+              onClick={() => setShowCreate(true)}
+              className="bg-olimpics-green-primary hover:bg-olimpics-green-secondary"
+            >
+              <Plus className="h-4 w-4 mr-1.5" />
+              Criar Chamada
+            </Button>
+          )}
         </div>
       ) : (
         <div className="space-y-2">

--- a/src/components/monitor/attendance-session-detail/useAttendanceLogic.ts
+++ b/src/components/monitor/attendance-session-detail/useAttendanceLogic.ts
@@ -12,14 +12,14 @@ export const useAttendanceLogic = (
     if (existingAttendances && athletes) {
       const newAttendanceData = new Map();
       
-      // Primeiro, inicializar todos os atletas com status 'presente' (padrão)
+      // Primeiro, inicializar todos os atletas com status 'ausente' (padrão)
       athletes.forEach(athlete => {
         newAttendanceData.set(athlete.id, {
-          status: 'presente',
+          status: 'ausente',
           attendance_id: undefined
         });
       });
-      
+
       // Depois, atualizar com os dados existentes se houver
       existingAttendances.forEach(attendance => {
         newAttendanceData.set(attendance.atleta_id, {
@@ -27,14 +27,14 @@ export const useAttendanceLogic = (
           attendance_id: attendance.id
         });
       });
-      
+
       setAttendanceData(newAttendanceData);
     } else if (athletes && !existingAttendances) {
-      // Se não há dados existentes, inicializar todos como presente
+      // Se não há dados existentes, inicializar todos como ausente
       const newAttendanceData = new Map();
       athletes.forEach(athlete => {
         newAttendanceData.set(athlete.id, {
-          status: 'presente',
+          status: 'ausente',
           attendance_id: undefined
         });
       });
@@ -43,15 +43,15 @@ export const useAttendanceLogic = (
   }, [existingAttendances, athletes]);
 
   const handleStatusChange = (athleteId: string, status: string) => {
-    const current = attendanceData.get(athleteId) || { status: 'presente' };
+    const current = attendanceData.get(athleteId) || { status: 'ausente' };
     setAttendanceData(new Map(attendanceData.set(athleteId, { ...current, status })));
   };
 
   const getStatusCounts = () => {
     if (!athletes) return { presente: 0, ausente: 0, atrasado: 0, total: 0 };
-    
+
     let presente = 0, ausente = 0, atrasado = 0;
-    
+
     athletes.forEach(athlete => {
       const data = attendanceData.get(athlete.id);
       if (data) {
@@ -59,10 +59,10 @@ export const useAttendanceLogic = (
           case 'presente': presente++; break;
           case 'atrasado': atrasado++; break;
           case 'ausente': ausente++; break;
-          default: presente++; break;
+          default: ausente++; break;
         }
       } else {
-        presente++;
+        ausente++;
       }
     });
     

--- a/src/hooks/useEventSessions.ts
+++ b/src/hooks/useEventSessions.ts
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/contexts/AuthContext";
+import { MonitorSession } from "./useMonitorSessions";
+
+/**
+ * Fetches ALL chamadas across ALL modalities of the current event.
+ * Used by Organizers who should see the full attendance history.
+ */
+export const useEventSessions = () => {
+  const { currentEventId } = useAuth();
+
+  return useQuery({
+    queryKey: ['event-sessions', currentEventId],
+    queryFn: async (): Promise<MonitorSession[]> => {
+      if (!currentEventId) return [];
+
+      // Get all modalidade_representantes for modalities in this event
+      const { data: reps, error: repsErr } = await supabase
+        .from('modalidade_representantes')
+        .select('id, modalidades!inner(evento_id)')
+        .eq('modalidades.evento_id', currentEventId);
+
+      if (repsErr) throw repsErr;
+      if (!reps?.length) return [];
+
+      const repIds = reps.map(r => r.id);
+
+      const { data: sessions, error } = await supabase
+        .from('chamadas')
+        .select(`
+          *,
+          modalidade_representantes!modalidade_rep_id (
+            modalidades!modalidade_representantes_modalidade_id_fkey (nome),
+            filiais!modalidade_representantes_filial_id_fkey (nome)
+          )
+        `)
+        .in('modalidade_rep_id', repIds)
+        .order('data_hora_inicio', { ascending: false });
+
+      if (error) throw error;
+      return (sessions ?? []) as MonitorSession[];
+    },
+    enabled: !!currentEventId,
+    staleTime: 0,
+  });
+};

--- a/src/pages/Cronograma.tsx
+++ b/src/pages/Cronograma.tsx
@@ -89,11 +89,9 @@ function dedup(activities: ScheduleActivity[]): ScheduleActivity[] {
 function ActivityCard({
   activity,
   colorMap,
-  compact = false,
 }: {
   activity: ScheduleActivity;
   colorMap: Map<string, typeof PALETTE[0]>;
-  compact?: boolean;
 }) {
   const color = activity.global
     ? GLOBAL_COLOR
@@ -112,41 +110,37 @@ function ActivityCard({
         <p className={cn('text-xs font-semibold leading-snug', color.text)}>{activity.atividade}</p>
       </div>
 
-      {!compact && (
-        <>
-          {activity.local && (
-            <div className="flex items-center gap-1 mt-1.5 pl-4">
-              <MapPin className="h-3 w-3 text-muted-foreground flex-shrink-0" />
-              <span className="text-[11px] text-muted-foreground leading-tight">{activity.local}</span>
-            </div>
-          )}
-          {activity.horario_inicio && (
-            <div className="flex items-center gap-1 mt-1 pl-4">
-              <Clock className="h-3 w-3 text-muted-foreground flex-shrink-0" />
-              <span className="text-[11px] text-muted-foreground">
-                {fmtTime(activity.horario_inicio)}
-                {activity.horario_fim ? ` – ${fmtTime(activity.horario_fim)}` : ''}
-              </span>
-            </div>
-          )}
-          {activity.modalidade_nome && (
-            <div className="mt-1.5 pl-4">
-              <span className={cn(
-                'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium border',
-                color.bg, color.border, color.text,
-              )}>
-                {activity.modalidade_nome}
-              </span>
-            </div>
-          )}
-          {activity.global && (
-            <div className="mt-1.5 pl-4">
-              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 border border-emerald-200 px-2 py-0.5 text-[10px] font-medium text-emerald-700">
-                <Globe className="h-2.5 w-2.5" /> Todos
-              </span>
-            </div>
-          )}
-        </>
+      {activity.local && (
+        <div className="flex items-center gap-1 mt-1.5 pl-4">
+          <MapPin className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+          <span className="text-[11px] text-muted-foreground leading-tight">{activity.local}</span>
+        </div>
+      )}
+      {activity.horario_inicio && (
+        <div className="flex items-center gap-1 mt-1 pl-4">
+          <Clock className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+          <span className="text-[11px] text-muted-foreground">
+            {fmtTime(activity.horario_inicio)}
+            {activity.horario_fim ? ` – ${fmtTime(activity.horario_fim)}` : ''}
+          </span>
+        </div>
+      )}
+      {activity.modalidade_nome && (
+        <div className="mt-1.5 pl-4">
+          <span className={cn(
+            'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium border',
+            color.bg, color.border, color.text,
+          )}>
+            {activity.modalidade_nome}
+          </span>
+        </div>
+      )}
+      {activity.global && (
+        <div className="mt-1.5 pl-4">
+          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 border border-emerald-200 px-2 py-0.5 text-[10px] font-medium text-emerald-700">
+            <Globe className="h-2.5 w-2.5" /> Todos
+          </span>
+        </div>
       )}
     </div>
   );
@@ -227,7 +221,7 @@ function WeekGrid({
                       {activities.length > 0 ? (
                         <div className="space-y-1.5">
                           {activities.map((act, i) => (
-                            <ActivityCard key={i} activity={act} colorMap={colorMap} compact />
+                            <ActivityCard key={i} activity={act} colorMap={colorMap} />
                           ))}
                         </div>
                       ) : (

--- a/supabase/migrations/20260624_chamadas_read_access.sql
+++ b/supabase/migrations/20260624_chamadas_read_access.sql
@@ -1,0 +1,36 @@
+-- Permite leitura de chamadas e presenças para todos os usuários autenticados.
+-- Necessário para: aba Frequência do Organizador, visualização de chamadas pelo
+-- Organizador na tela Filósofo Monitor, e exibição de presenças ao abrir uma chamada.
+-- A UI já é protegida por controle de papel (role-based routing).
+
+-- chamadas
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'chamadas'
+      AND policyname = 'chamadas_select_authenticated'
+  ) THEN
+    CREATE POLICY "chamadas_select_authenticated"
+    ON public.chamadas FOR SELECT TO authenticated
+    USING (true);
+  END IF;
+END$$;
+
+GRANT SELECT ON public.chamadas TO authenticated;
+
+-- chamada_presencas
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'chamada_presencas'
+      AND policyname = 'chamada_presencas_select_authenticated'
+  ) THEN
+    CREATE POLICY "chamada_presencas_select_authenticated"
+    ON public.chamada_presencas FOR SELECT TO authenticated
+    USING (true);
+  END IF;
+END$$;
+
+GRANT SELECT ON public.chamada_presencas TO authenticated;

--- a/supabase/migrations/20260624_chamadas_write_admins.sql
+++ b/supabase/migrations/20260624_chamadas_write_admins.sql
@@ -1,0 +1,48 @@
+-- Permite INSERT/UPDATE/DELETE em chamada_presencas para Organizadores e Admins.
+-- Necessário para que Organizadores possam editar presenças de chamadas passadas.
+-- Monitores já possuem sua policy própria de escrita.
+--
+-- PRÉ-REQUISITO: rodar antes o diagnóstico abaixo e confirmar que os nomes
+-- de colunas do join perfis→perfis_tipo estão corretos:
+--
+--   SELECT pu.usuario_id, pt.codigo
+--   FROM papeis_usuarios pu
+--   JOIN perfis p ON pu.perfil_id = p.id
+--   JOIN perfis_tipo pt ON p.perfil_tipo_id = pt.id
+--   LIMIT 1;
+--
+-- Se a coluna se chamar diferente de "perfil_tipo_id" ou "codigo", ajuste abaixo.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'chamada_presencas'
+      AND policyname = 'chamada_presencas_write_admins'
+  ) THEN
+    CREATE POLICY "chamada_presencas_write_admins"
+    ON public.chamada_presencas FOR ALL TO authenticated
+    USING (
+      EXISTS (
+        SELECT 1
+        FROM public.papeis_usuarios pu
+        JOIN public.perfis p ON pu.perfil_id = p.id
+        JOIN public.perfis_tipo pt ON p.perfil_tipo_id = pt.id
+        WHERE pu.usuario_id = auth.uid()
+          AND pt.codigo IN ('ORG', 'ADM', 'MST')
+      )
+    )
+    WITH CHECK (
+      EXISTS (
+        SELECT 1
+        FROM public.papeis_usuarios pu
+        JOIN public.perfis p ON pu.perfil_id = p.id
+        JOIN public.perfis_tipo pt ON p.perfil_tipo_id = pt.id
+        WHERE pu.usuario_id = auth.uid()
+          AND pt.codigo IN ('ORG', 'ADM', 'MST')
+      )
+    );
+  END IF;
+END$$;
+
+GRANT INSERT, UPDATE, DELETE ON public.chamada_presencas TO authenticated;


### PR DESCRIPTION
## Resumo

Sete melhorias/correções em quatro áreas do sistema.

### Frontend (entram com o deploy)

**A1 — Padrão "Faltou" em nova chamada**
- `AttendanceCreationDialog.tsx`: atletas iniciam como `ausente` (antes: `presente`)
- `useAttendanceLogic.ts`: mesmo padrão na edição de chamadas existentes
- Monitor marca apenas quem compareceu, reduzindo cliques

**A2 — Cronograma desktop com detalhes completos**
- `Cronograma.tsx`: removido `compact` do `ActivityCard` no WeekGrid
- Desktop agora exibe local, horário, modalidade e selo "Todos" igual ao mobile

**A3 — Justificativa condicional de modalidade**
- `ModalitiesTable.tsx`: Select de status não bloqueia mais sem justificativa
- `useModalityHandlers.ts`: valida e exige justificativa **apenas** para `pendente`/`cancelado`; `confirmado`/`rejeitado` passam sem justificativa

**A4 — Visualização em tabela paginada dos atletas**
- `PaginatedAthleteList.tsx`: toggle Cards ↔ Tabela (botões no topo)
- Novo `AthleteTable.tsx`: tabela com colunas Nome, Pagamento, Modalidades, Filial
- Clicar linha abre o mesmo diálogo de detalhe dos cards
- Novo `statusColors.ts`: cores de status extraídas e compartilhadas
- `AthleteRegistrationCard.tsx`: aceita `dialogOpen`/`onDialogOpenChange` opcionais

**A5 — Organizador vê todas as chamadas do evento**
- Novo `useEventSessions.ts`: busca chamadas de todas as modalidades do evento
- `MonitorAttendancePage.tsx`: detecta perfil ORG/ADM via `useUserRoleCheck`; se organizador → usa `useEventSessions`; botão "Nova Chamada" aparece apenas para monitores

### Banco de dados (rodar no SQL Editor de sb.nova-acropole.org.br)

**B1** — `20260624_chamadas_read_access.sql`: policy SELECT em `chamadas` e `chamada_presencas` para autenticados (corrige Frequência vazia e lista de presenças vazia ao abrir chamada)

**B2** — `20260624_chamadas_write_admins.sql`: policy ALL em `chamada_presencas` para ORG/ADM/MST (permite Organizador editar presenças)

> **B3 — cascata pagamento→modalidades**: o frontend já está correto (só chama `atualizar_status_pagamento`). A cascata está na RPC/trigger no banco. Rodar e enviar resultado:
> ```sql
> SELECT pg_get_functiondef('public.atualizar_status_pagamento'::regproc);
> SELECT tgname, pg_get_triggerdef(oid) FROM pg_trigger
> WHERE tgrelid = 'public.pagamentos'::regclass AND NOT tgisinternal;
> ```

## Checklist de testes

- [ ] Nova chamada: atletas iniciam como "Faltou"
- [ ] Editar chamada existente: presenças salvas são mantidas
- [ ] Cronograma desktop: local, horário e modalidade aparecem nas células
- [ ] Trocar modalidade para "confirmado" sem justificativa → sucesso
- [ ] Trocar para "pendente"/"cancelado" sem justificativa → toast de erro
- [ ] Toggle Cards/Tabela na aba Atletas; clicar linha abre detalhe
- [ ] Como Organizador na tela Monitor: aba Chamadas lista todas as modalidades
- [ ] Após rodar B1: aba Frequência do Organizador deixa de ficar vazia
- [ ] `npx tsc --noEmit` sem erros ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)