### PR TITLE
fix: remover cascata pagamento→modalidades na RPC

### DIFF
--- a/supabase/migrations/20260624_fix_payment_cascade.sql
+++ b/supabase/migrations/20260624_fix_payment_cascade.sql
@@ -1,0 +1,21 @@
+-- Remove cascata de pagamento → inscricoes_modalidades.
+-- A RPC original atualizava todas as modalidades do atleta junto com o pagamento,
+-- mas cada modalidade deve ter seu status gerenciado individualmente.
+
+CREATE OR REPLACE FUNCTION public.atualizar_status_pagamento(
+  p_atleta_id uuid,
+  p_novo_status text
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE public.pagamentos
+    SET status = p_novo_status,
+        data_validacao = CASE
+            WHEN p_novo_status = 'confirmado' THEN NOW()
+            ELSE NULL
+        END
+    WHERE atleta_id = p_atleta_id;
+END;
+$$;


### PR DESCRIPTION
## Problema

A RPC \`atualizar_status_pagamento\` atualizava **todas** as \`inscricoes_modalidades\` do atleta junto com o status de pagamento, causando que uma alteração de pagamento sobrescrevesse os status individuais de cada modalidade.

## Causa encontrada

```sql
-- BLOCO REMOVIDO da RPC:
UPDATE public.inscricoes_modalidades
SET status = p_novo_status,
    justificativa_status = 'Status atualizado via pagamento'
WHERE atleta_id = p_atleta_id;
```

## Fix

`20260624_fix_payment_cascade.sql` — redefine a RPC mantendo apenas:
- `UPDATE pagamentos SET status, data_validacao`

Cada modalidade continua sendo ajustada individualmente via `atualizar_status_inscricao`.

## Verificação

- Trocar pagamento pendente → confirmado: modalidades mantêm seus status individuais
- Trocar para cancelado: mesmo comportamento
- `atualizar_status_inscricao` continua funcionando por modalidade

🤖 Generated with [Claude Code](https://claude.com/claude-code)