### PR TITLE
fix: organizador enxerga todas as chamadas do evento

### DIFF
--- a/src/components/monitor/MonitorAttendancePage.tsx
+++ b/src/components/monitor/MonitorAttendancePage.tsx
@@ -103,7 +103,8 @@ export default function MonitorAttendancePage() {
   const [detailSessionId, setDetailSessionId] = useState<string | null>(null);
 
   const { user, currentEventId } = useAuth();
-  const { isOrganizer } = useUserRoleCheck(user?.id ?? '', currentEventId ?? '');
+  const { data: roleData } = useUserRoleCheck(user?.id ?? '', currentEventId ?? '');
+  const isOrganizer = roleData?.isOrganizer ?? false;
 
   const { data: modalities, isLoading: modalitiesLoading } = useMonitorModalities();
   const { data: monitorSessions, isLoading: monitorSessionsLoading } = useAllMonitorSessions();


### PR DESCRIPTION
## Problema

Organizador na tela Filósofo Monitor via apenas as chamadas das suas próprias modalidades, igual a um Filósofo Monitor.

## Causa

\`useUserRoleCheck\` retorna \`UseQueryResult\`. O campo \`isOrganizer\` está em \`.data\`, não no nível raiz. A desestruturação incorreta:

\`\`\`typescript
// Sempre undefined — desestrutura do QueryResult, não do .data
const { isOrganizer } = useUserRoleCheck(...);
\`\`\`

Como \`isOrganizer\` era \`undefined\` (falsy), o código sempre usava \`useAllMonitorSessions\` em vez de \`useEventSessions\`.

## Fix

\`\`\`typescript
const { data: roleData } = useUserRoleCheck(user?.id ?? '', currentEventId ?? '');
const isOrganizer = roleData?.isOrganizer ?? false;
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)