### PR TITLE
feat: auditoria de chamadas/presenças + nome criador + excluir chamada (#46)

### DIFF
--- a/src/components/monitor/AttendanceSessionDetail.tsx
+++ b/src/components/monitor/AttendanceSessionDetail.tsx
@@ -1,29 +1,133 @@
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, History, ChevronDown, ChevronUp } from "lucide-react";
 import { useSessionAttendance, useAthletesForAttendance } from "@/hooks/useSessionAttendance";
 import { useMonitorMutations } from "@/hooks/useMonitorMutations";
+import { useChamadaAuditLog, AuditLogEntry } from "@/hooks/useChamadaAuditLog";
 import { LoadingImage } from "@/components/ui/loading-image";
 import { useSessionDetail } from "./attendance-session-detail/useSessionDetail";
 import { useAttendanceLogic } from "./attendance-session-detail/useAttendanceLogic";
 import { SessionHeader } from "./attendance-session-detail/SessionHeader";
 import { AttendanceSummaryCards } from "./attendance-session-detail/AttendanceSummaryCards";
 import { AthletesList } from "./attendance-session-detail/AthletesList";
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { cn } from '@/lib/utils';
 
 interface AttendanceSessionDetailProps {
   sessionId: string;
   onBack: () => void;
 }
 
+/* ── helpers para o log de auditoria ─────────────────────── */
+
+function operationLabel(entry: AuditLogEntry): string {
+  if (entry.entidade === 'chamada') {
+    if (entry.operation === 'INSERT') return 'Chamada criada';
+    if (entry.operation === 'UPDATE') return 'Chamada editada';
+    return 'Chamada excluída';
+  }
+  // presenca
+  if (entry.operation === 'INSERT') return 'Presença registrada';
+  if (entry.operation === 'UPDATE') return 'Presença alterada';
+  return 'Presença removida';
+}
+
+function operationBadgeVariant(op: string): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (op === 'INSERT') return 'default';
+  if (op === 'UPDATE') return 'secondary';
+  return 'destructive';
+}
+
+function statusLabel(status: string | undefined): string {
+  if (status === 'presente') return 'Presente';
+  if (status === 'ausente') return 'Ausente';
+  if (status === 'atrasado') return 'Atrasado';
+  return status ?? '—';
+}
+
+function AuditEntry({ entry }: { entry: AuditLogEntry }) {
+  const isPresenca = entry.entidade === 'presenca';
+  const oldStatus = entry.old_data?.status;
+  const newStatus = entry.new_data?.status;
+  const atletaNome = entry.new_data?.atleta_id ?? entry.old_data?.atleta_id ?? null;
+
+  return (
+    <div className="flex items-start gap-3 py-2.5 border-b last:border-0">
+      <div className="flex-shrink-0 w-2 h-2 rounded-full mt-1.5 bg-muted-foreground/40" />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge variant={operationBadgeVariant(entry.operation)} className="text-[10px] h-4 px-1.5">
+            {operationLabel(entry)}
+          </Badge>
+          {isPresenca && entry.operation === 'UPDATE' && oldStatus && newStatus && (
+            <span className="text-xs text-muted-foreground">
+              {statusLabel(oldStatus)} → {statusLabel(newStatus)}
+            </span>
+          )}
+          {isPresenca && entry.operation === 'INSERT' && newStatus && (
+            <span className="text-xs text-muted-foreground">{statusLabel(newStatus)}</span>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          <span className="font-medium text-foreground">{entry.usuario_nome}</span>
+          {' · '}
+          {format(new Date(entry.timestamp), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function AuditLogSection({ chamadaId }: { chamadaId: string }) {
+  const [open, setOpen] = useState(false);
+  const { data: entries, isLoading } = useChamadaAuditLog(chamadaId);
+
+  if (!isLoading && (!entries || entries.length === 0)) return null;
+
+  return (
+    <Card>
+      <button
+        className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium hover:bg-muted/40 transition-colors"
+        onClick={() => setOpen(v => !v)}
+      >
+        <span className="flex items-center gap-2">
+          <History className="h-4 w-4 text-muted-foreground" />
+          Histórico de alterações
+          {!isLoading && entries && entries.length > 0 && (
+            <Badge variant="outline" className="text-[10px] h-4 px-1.5">{entries.length}</Badge>
+          )}
+        </span>
+        {open ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />}
+      </button>
+
+      {open && (
+        <CardContent className="pt-0 pb-3 px-4">
+          {isLoading ? (
+            <p className="text-xs text-muted-foreground py-2">Carregando histórico…</p>
+          ) : (
+            <div>
+              {entries!.map(e => <AuditEntry key={e.id} entry={e} />)}
+            </div>
+          )}
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+/* ── main component ──────────────────────────────────────── */
+
 export default function AttendanceSessionDetail({ sessionId, onBack }: AttendanceSessionDetailProps) {
   const { data: session, isLoading: sessionLoading } = useSessionDetail(sessionId);
   const { data: existingAttendances, isLoading: attendancesLoading } = useSessionAttendance(sessionId);
   const { data: athletes, isLoading: athletesLoading } = useAthletesForAttendance(session?.modalidade_rep_id || null);
-  
+
   const { saveAttendances } = useMonitorMutations();
-  
+
   const {
     attendanceData,
     handleStatusChange,
@@ -63,7 +167,7 @@ export default function AttendanceSessionDetail({ sessionId, onBack }: Attendanc
           </Button>
           <h1 className="text-xl font-bold text-olimpics-text">Sessão não encontrada</h1>
         </div>
-        
+
         <Card>
           <CardContent className="p-6 text-center">
             <p className="text-gray-500">
@@ -85,7 +189,7 @@ export default function AttendanceSessionDetail({ sessionId, onBack }: Attendanc
           </Button>
           <h1 className="text-xl font-bold text-olimpics-text">{session.descricao}</h1>
         </div>
-        
+
         <Card>
           <CardContent className="p-6 text-center">
             <p className="text-gray-500">
@@ -115,6 +219,8 @@ export default function AttendanceSessionDetail({ sessionId, onBack }: Attendanc
         attendanceData={attendanceData}
         onStatusChange={handleStatusChange}
       />
+
+      <AuditLogSection chamadaId={sessionId} />
     </div>
   );
 }

--- a/src/components/monitor/MonitorAttendancePage.tsx
+++ b/src/components/monitor/MonitorAttendancePage.tsx
@@ -3,11 +3,22 @@ import React, { useState } from 'react';
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Plus, Calendar, Clock, ChevronRight, AlertTriangle } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Plus, Calendar, Clock, ChevronRight, AlertTriangle, Trash2, User } from "lucide-react";
 import { useMonitorModalities } from "@/hooks/useMonitorModalities";
 import { useAllMonitorSessions } from "@/hooks/useAllMonitorSessions";
 import { useEventSessions } from "@/hooks/useEventSessions";
 import { useUserRoleCheck } from "@/hooks/useUserRoleCheck";
+import { useMonitorMutations } from "@/hooks/useMonitorMutations";
 import { useAuth } from "@/contexts/AuthContext";
 import { MonitorSession } from "@/hooks/useMonitorSessions";
 import { LoadingImage } from "@/components/ui/loading-image";
@@ -22,15 +33,18 @@ import { cn } from '@/lib/utils';
 
 function SessionRow({
   session,
+  isOrganizer,
   onView,
   onEdit,
+  onDelete,
 }: {
   session: MonitorSession;
+  isOrganizer: boolean;
   onView: (id: string) => void;
   onEdit: (s: MonitorSession) => void;
+  onDelete: (s: MonitorSession) => void;
 }) {
-  const hasObs = !!(session as any).observacoes?.trim();
-  const dateStr = format(new Date(session.data_hora_inicio), "dd MMM yyyy", { locale: ptBR });
+  const hasObs = !!session.observacoes?.trim();
   const timeStr = format(new Date(session.data_hora_inicio), "HH:mm", { locale: ptBR });
   const endTime = session.data_hora_fim
     ? format(new Date(session.data_hora_fim), "HH:mm", { locale: ptBR })
@@ -69,10 +83,16 @@ function SessionRow({
             {session.modalidade_representantes.modalidades.nome}
           </span>
         </div>
+        {session.criador_nome && (
+          <p className="text-[11px] text-muted-foreground mt-0.5 flex items-center gap-1">
+            <User className="h-3 w-3 flex-shrink-0" />
+            <span className="truncate">{session.criador_nome}</span>
+          </p>
+        )}
         {hasObs && (
           <p className="text-[11px] text-amber-600 mt-0.5 flex items-center gap-1">
             <AlertTriangle className="h-3 w-3 flex-shrink-0" />
-            <span className="truncate">{(session as any).observacoes}</span>
+            <span className="truncate">{session.observacoes}</span>
           </p>
         )}
       </div>
@@ -87,6 +107,16 @@ function SessionRow({
         >
           Editar
         </Button>
+        {isOrganizer && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+            onClick={() => onDelete(session)}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
         <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors" />
       </div>
     </div>
@@ -101,10 +131,13 @@ export default function MonitorAttendancePage() {
   const [showEdit, setShowEdit] = useState(false);
   const [sessionToEdit, setSessionToEdit] = useState<MonitorSession | null>(null);
   const [detailSessionId, setDetailSessionId] = useState<string | null>(null);
+  const [sessionToDelete, setSessionToDelete] = useState<MonitorSession | null>(null);
 
   const { user, currentEventId } = useAuth();
   const { data: roleData } = useUserRoleCheck(user?.id ?? '', currentEventId ?? '');
   const isOrganizer = roleData?.isOrganizer ?? false;
+
+  const { deleteSession } = useMonitorMutations();
 
   const { data: modalities, isLoading: modalitiesLoading } = useMonitorModalities();
   const { data: monitorSessions, isLoading: monitorSessionsLoading } = useAllMonitorSessions();
@@ -160,6 +193,12 @@ export default function MonitorAttendancePage() {
         m.modalidades.nome === s.modalidade_representantes.modalidades.nome
     );
   });
+
+  const handleDeleteConfirm = async () => {
+    if (!sessionToDelete) return;
+    await deleteSession.mutateAsync(sessionToDelete.id);
+    setSessionToDelete(null);
+  };
 
   return (
     <div className="space-y-4 max-w-full">
@@ -224,8 +263,10 @@ export default function MonitorAttendancePage() {
             <SessionRow
               key={s.id}
               session={s}
+              isOrganizer={isOrganizer}
               onView={setDetailSessionId}
               onEdit={s => { setSessionToEdit(s); setShowEdit(true); }}
+              onDelete={setSessionToDelete}
             />
           ))}
         </div>
@@ -246,6 +287,29 @@ export default function MonitorAttendancePage() {
           session={sessionToEdit}
         />
       )}
+
+      {/* Confirmação de exclusão */}
+      <AlertDialog open={!!sessionToDelete} onOpenChange={open => !open && setSessionToDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Excluir chamada?</AlertDialogTitle>
+            <AlertDialogDescription>
+              A chamada <strong>{sessionToDelete?.descricao || "selecionada"}</strong> e todas as
+              presenças registradas nela serão excluídas permanentemente. Esta ação não pode ser desfeita.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleDeleteConfirm}
+              disabled={deleteSession.isPending}
+            >
+              {deleteSession.isPending ? "Excluindo…" : "Excluir"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/hooks/useAllMonitorSessions.ts
+++ b/src/hooks/useAllMonitorSessions.ts
@@ -43,7 +43,17 @@ export const useAllMonitorSessions = () => {
         .order('data_hora_inicio', { ascending: false });
 
       if (error) throw error;
-      return (sessions ?? []) as MonitorSession[];
+      const list = (sessions ?? []) as MonitorSession[];
+      if (!list.length) return list;
+
+      // Resolve names for criado_por
+      const userIds = [...new Set(list.map(s => s.criado_por).filter(Boolean))];
+      const { data: users } = await supabase
+        .from('usuarios')
+        .select('id, nome_completo')
+        .in('id', userIds);
+      const nameMap = new Map((users ?? []).map(u => [u.id, u.nome_completo]));
+      return list.map(s => ({ ...s, criador_nome: nameMap.get(s.criado_por) ?? undefined }));
     },
     enabled: modalidadeIds.length > 0,
     staleTime: 0,

--- a/src/hooks/useChamadaAuditLog.ts
+++ b/src/hooks/useChamadaAuditLog.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/lib/supabase';
+
+export interface AuditLogEntry {
+  id: number;
+  entidade: 'chamada' | 'presenca';
+  operation: 'INSERT' | 'UPDATE' | 'DELETE';
+  chamada_id: string;
+  atleta_id: string | null;
+  old_data: Record<string, any> | null;
+  new_data: Record<string, any> | null;
+  user_id: string | null;
+  timestamp: string;
+  usuario_nome: string;
+}
+
+export function useChamadaAuditLog(chamadaId: string | null) {
+  return useQuery({
+    queryKey: ['chamada-audit-log', chamadaId],
+    queryFn: async (): Promise<AuditLogEntry[]> => {
+      if (!chamadaId) return [];
+
+      const { data: entries, error } = await supabase
+        .from('chamadas_audit_log')
+        .select('*')
+        .eq('chamada_id', chamadaId)
+        .order('timestamp', { ascending: false });
+
+      // Tabela pode não existir ainda (antes da migração)
+      if (error) {
+        if (error.code === '42P01') return []; // relation does not exist
+        throw error;
+      }
+      if (!entries?.length) return [];
+
+      const userIds = [...new Set(entries.map(e => e.user_id).filter(Boolean))] as string[];
+      const { data: users } = await supabase
+        .from('usuarios')
+        .select('id, nome_completo')
+        .in('id', userIds);
+      const nameMap = new Map((users ?? []).map(u => [u.id, u.nome_completo]));
+
+      return entries.map(e => ({
+        ...e,
+        usuario_nome: nameMap.get(e.user_id) ?? 'Desconhecido',
+      })) as AuditLogEntry[];
+    },
+    enabled: !!chamadaId,
+    staleTime: 30 * 1000,
+  });
+}

--- a/src/hooks/useEventSessions.ts
+++ b/src/hooks/useEventSessions.ts
@@ -39,7 +39,17 @@ export const useEventSessions = () => {
         .order('data_hora_inicio', { ascending: false });
 
       if (error) throw error;
-      return (sessions ?? []) as MonitorSession[];
+      const list = (sessions ?? []) as MonitorSession[];
+      if (!list.length) return list;
+
+      // Resolve names for criado_por
+      const userIds = [...new Set(list.map(s => s.criado_por).filter(Boolean))];
+      const { data: users } = await supabase
+        .from('usuarios')
+        .select('id, nome_completo')
+        .in('id', userIds);
+      const nameMap = new Map((users ?? []).map(u => [u.id, u.nome_completo]));
+      return list.map(s => ({ ...s, criador_nome: nameMap.get(s.criado_por) ?? undefined }));
     },
     enabled: !!currentEventId,
     staleTime: 0,

--- a/src/hooks/useMonitorMutations.ts
+++ b/src/hooks/useMonitorMutations.ts
@@ -138,11 +138,13 @@ export const useMonitorMutations = () => {
     mutationFn: async ({ id, data }: { id: string; data: Partial<CreateSessionData> }) => {
       console.log('Updating session:', id, data);
 
+      if (!user?.id) throw new Error('Usuário não autenticado');
       const { error } = await supabase
         .from('chamadas')
         .update({
           ...data,
-          atualizado_em: new Date().toISOString()
+          atualizado_em: new Date().toISOString(),
+          atualizado_por: user.id,
         })
         .eq('id', id);
 
@@ -190,7 +192,9 @@ export const useMonitorMutations = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['monitor-sessions'] });
       queryClient.invalidateQueries({ queryKey: ['all-monitor-sessions'] });
+      queryClient.invalidateQueries({ queryKey: ['event-sessions'] });
       queryClient.invalidateQueries({ queryKey: ['monitor-reports'] });
+      queryClient.invalidateQueries({ queryKey: ['organizer-attendance-report'] });
       toast.success('Chamada excluída com sucesso!');
     },
     onError: (error: any) => {
@@ -205,40 +209,22 @@ export const useMonitorMutations = () => {
         throw new Error('Usuário não autenticado');
       }
 
-      console.log('Saving attendances:', attendances);
-
-      // Primeiro, deletar presenças existentes para esta chamada
-      const chamadaId = attendances[0]?.chamada_id;
-      if (chamadaId) {
-        const { error: deleteError } = await supabase
-          .from('chamada_presencas')
-          .delete()
-          .eq('chamada_id', chamadaId);
-
-        if (deleteError) {
-          console.error('Error deleting existing attendances:', deleteError);
-          throw new Error(`Erro ao remover presenças existentes: ${deleteError.message}`);
-        }
-      }
-
-      // Depois inserir as novas presenças
-      const attendancesToInsert = attendances.map(attendance => ({
-        chamada_id: attendance.chamada_id,
-        atleta_id: attendance.atleta_id,
-        status: attendance.status,
-        registrado_por: user.id
+      const records = attendances.map(a => ({
+        chamada_id: a.chamada_id,
+        atleta_id: a.atleta_id,
+        status: a.status,
+        registrado_por: user.id,
       }));
 
-      const { error: insertError } = await supabase
+      // Upsert por (chamada_id, atleta_id) — gera UPDATE apenas se status mudou (trigger otimizado)
+      // Requer UNIQUE(chamada_id, atleta_id) em chamada_presencas (migração 20260624_chamadas_audit_log.sql)
+      const { error } = await supabase
         .from('chamada_presencas')
-        .insert(attendancesToInsert);
+        .upsert(records, { onConflict: 'chamada_id,atleta_id' });
 
-      if (insertError) {
-        console.error('Error inserting new attendances:', insertError);
-        throw new Error(`Erro ao salvar presenças: ${insertError.message}`);
+      if (error) {
+        throw new Error(`Erro ao salvar presenças: ${error.message}`);
       }
-
-      console.log('Attendances saved successfully');
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['session-attendance'] });

--- a/src/hooks/useMonitorSessions.ts
+++ b/src/hooks/useMonitorSessions.ts
@@ -8,8 +8,12 @@ export interface MonitorSession {
   data_hora_inicio: string;
   data_hora_fim: string | null;
   descricao: string;
+  observacoes: string | null;
   criado_em: string;
   criado_por: string;
+  atualizado_em: string | null;
+  atualizado_por: string | null;
+  criador_nome?: string;
   modalidade_representantes: {
     modalidades: {
       nome: string;

--- a/supabase/migrations/20260624_chamadas_audit_log.sql
+++ b/supabase/migrations/20260624_chamadas_audit_log.sql
@@ -1,0 +1,157 @@
+-- ══════════════════════════════════════════════════════════════════════
+-- Auditoria de chamadas + presenças  (Items 4 e 5 do plano 2026-06-24)
+-- Executar no SQL Editor de sb.nova-acropole.org.br ANTES de fazer merge
+-- do PR feat/chamadas-audit-delete em main.
+-- ══════════════════════════════════════════════════════════════════════
+
+-- 1. Coluna atualizado_por em chamadas
+ALTER TABLE public.chamadas
+  ADD COLUMN IF NOT EXISTS atualizado_por uuid REFERENCES public.usuarios(id);
+
+-- 2. UNIQUE em chamada_presencas (necessário para upsert no app)
+--    Remove duplicatas mantendo o registro mais recente antes de criar a constraint.
+DO $$
+BEGIN
+  -- limpa duplicatas (mantém o id maior, i.e., o mais recente)
+  DELETE FROM public.chamada_presencas a
+  USING public.chamada_presencas b
+  WHERE a.id < b.id
+    AND a.chamada_id = b.chamada_id
+    AND a.atleta_id  = b.atleta_id;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.chamada_presencas'::regclass
+      AND conname  = 'chamada_presencas_chamada_atleta_key'
+  ) THEN
+    ALTER TABLE public.chamada_presencas
+      ADD CONSTRAINT chamada_presencas_chamada_atleta_key
+      UNIQUE (chamada_id, atleta_id);
+  END IF;
+END$$;
+
+-- 3. Tabela de auditoria
+CREATE TABLE IF NOT EXISTS public.chamadas_audit_log (
+  id          bigserial PRIMARY KEY,
+  entidade    text       NOT NULL CHECK (entidade IN ('chamada', 'presenca')),
+  operation   text       NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+  chamada_id  uuid       NOT NULL,
+  atleta_id   uuid,
+  old_data    jsonb,
+  new_data    jsonb,
+  user_id     uuid       REFERENCES public.usuarios(id),
+  timestamp   timestamptz NOT NULL DEFAULT now()
+);
+
+-- índice para buscas por chamada (exibição do histórico)
+CREATE INDEX IF NOT EXISTS chamadas_audit_log_chamada_id_idx
+  ON public.chamadas_audit_log (chamada_id, timestamp DESC);
+
+-- 4. RLS + GRANT na tabela de auditoria
+ALTER TABLE public.chamadas_audit_log ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'chamadas_audit_log'
+      AND policyname = 'chamadas_audit_log_select'
+  ) THEN
+    CREATE POLICY "chamadas_audit_log_select"
+      ON public.chamadas_audit_log FOR SELECT TO authenticated USING (true);
+  END IF;
+END$$;
+
+GRANT SELECT ON public.chamadas_audit_log TO authenticated;
+
+-- 5. Função de trigger para chamadas (SECURITY DEFINER fura a RLS no insert do log)
+CREATE OR REPLACE FUNCTION public.fn_chamadas_audit()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO public.chamadas_audit_log
+      (entidade, operation, chamada_id, new_data, user_id)
+    VALUES ('chamada', 'INSERT', NEW.id, to_jsonb(NEW), NEW.criado_por);
+
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- ignora updates sem mudança real nos campos relevantes
+    IF (OLD.data_hora_inicio, OLD.data_hora_fim, OLD.descricao, OLD.observacoes)
+       IS NOT DISTINCT FROM
+       (NEW.data_hora_inicio, NEW.data_hora_fim, NEW.descricao, NEW.observacoes)
+    THEN
+      RETURN NEW;
+    END IF;
+    INSERT INTO public.chamadas_audit_log
+      (entidade, operation, chamada_id, old_data, new_data, user_id)
+    VALUES ('chamada', 'UPDATE', NEW.id, to_jsonb(OLD), to_jsonb(NEW), NEW.atualizado_por);
+
+  ELSIF TG_OP = 'DELETE' THEN
+    INSERT INTO public.chamadas_audit_log
+      (entidade, operation, chamada_id, old_data, user_id)
+    VALUES ('chamada', 'DELETE', OLD.id, to_jsonb(OLD), auth.uid());
+  END IF;
+  RETURN coalesce(NEW, OLD);
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_chamadas_audit ON public.chamadas;
+CREATE TRIGGER trg_chamadas_audit
+  AFTER INSERT OR UPDATE OR DELETE ON public.chamadas
+  FOR EACH ROW EXECUTE FUNCTION public.fn_chamadas_audit();
+
+-- 6. Função de trigger para chamada_presencas
+CREATE OR REPLACE FUNCTION public.fn_chamada_presencas_audit()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO public.chamadas_audit_log
+      (entidade, operation, chamada_id, atleta_id, new_data, user_id)
+    VALUES ('presenca', 'INSERT', NEW.chamada_id, NEW.atleta_id, to_jsonb(NEW), NEW.registrado_por);
+
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- ignora se status não mudou
+    IF OLD.status IS NOT DISTINCT FROM NEW.status THEN
+      RETURN NEW;
+    END IF;
+    INSERT INTO public.chamadas_audit_log
+      (entidade, operation, chamada_id, atleta_id, old_data, new_data, user_id)
+    VALUES ('presenca', 'UPDATE', NEW.chamada_id, NEW.atleta_id, to_jsonb(OLD), to_jsonb(NEW), NEW.registrado_por);
+
+  ELSIF TG_OP = 'DELETE' THEN
+    INSERT INTO public.chamadas_audit_log
+      (entidade, operation, chamada_id, atleta_id, old_data, user_id)
+    VALUES ('presenca', 'DELETE', OLD.chamada_id, OLD.atleta_id, to_jsonb(OLD), OLD.registrado_por);
+  END IF;
+  RETURN coalesce(NEW, OLD);
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_chamada_presencas_audit ON public.chamada_presencas;
+CREATE TRIGGER trg_chamada_presencas_audit
+  AFTER INSERT OR UPDATE OR DELETE ON public.chamada_presencas
+  FOR EACH ROW EXECUTE FUNCTION public.fn_chamada_presencas_audit();
+
+-- 7. RLS DELETE para chamadas (somente Organizadores/Admins/Mestres)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'chamadas'
+      AND policyname = 'chamadas_delete_admins'
+  ) THEN
+    CREATE POLICY "chamadas_delete_admins"
+      ON public.chamadas FOR DELETE TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.papeis_usuarios pu
+          JOIN public.perfis p       ON pu.perfil_id      = p.id
+          JOIN public.perfis_tipo pt ON p.perfil_tipo_id  = pt.id
+          WHERE pu.usuario_id = auth.uid()
+            AND pt.codigo IN ('ORG', 'ADM', 'MST')
+        )
+      );
+  END IF;
+END$$;
+
+GRANT DELETE ON public.chamadas TO authenticated;


### PR DESCRIPTION
## ⚠️ Requer migração antes do merge

Execute o SQL em `supabase/migrations/20260624_chamadas_audit_log.sql` no SQL Editor de `sb.nova-acropole.org.br` **antes de fazer merge deste PR**.

---

## Resumo

**Item 4 — Auditoria de chamadas:**
- Nova tabela `chamadas_audit_log` com triggers AFTER INSERT/UPDATE/DELETE em `chamadas` e `chamada_presencas`; triggers inteligentes (ignoram updates sem mudança real de campos relevantes)
- `useEventSessions` e `useAllMonitorSessions` resolvem o nome do FM criador via segunda query a `usuarios`
- Cada chamada na lista mostra "Criada por {nome do FM}"
- Na tela de detalhe: seção colapsável "Histórico de alterações" com badge de operação, nome do responsável e data/hora
- `saveAttendances` refatorado de delete-all+insert para upsert por `(chamada_id, atleta_id)` — elimina ruído falso no log; requer `UNIQUE(chamada_id, atleta_id)` da migração
- `updateSession` passa `atualizado_por: user.id`

**Item 5 — Excluir chamada:**
- RLS DELETE policy em `chamadas` para perfis ORG/ADM/MST (na migração)
- Botão lixeira em cada `SessionRow`, visível apenas para Organizador
- Confirmação via `AlertDialog` antes de excluir
- `deleteSession` invalida `event-sessions` e `organizer-attendance-report`

## Plano de teste
- [ ] Executar migração SQL no banco
- [ ] Como Organizador, lista de chamadas mostra "Criada por {nome FM}" em cada item
- [ ] Como Organizador, botão excluir (🗑) aparece; não-organizador não vê
- [ ] Excluir chamada de teste "Corrida em Revezamento 4x100m" → some da lista
- [ ] Editar uma chamada → seção "Histórico" aparece na tela de detalhe com a alteração
- [ ] Alterar status de presença e salvar → histórico registra UPDATE (não DELETE+INSERT)
- [ ] Salvar presenças sem alterar nada → histórico NÃO gera entradas novas
- [ ] `npx tsc --noEmit` sem erros

🤖 Generated with [Claude Code](https://claude.ai/claude-code)