### PR TITLE
fix: meta tags no-cache no index.html (#47)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <link rel="icon" type="image/png" href="/lovable-uploads/EECC_marca_portugues_cores_RGB.png" />
   <link rel="apple-touch-icon" href="/lovable-uploads/EECC_marca_portugues_cores_RGB.png" />
   <title>Olimpia Manager</title>


### PR DESCRIPTION
## Resumo

Após cada deploy na Lovable.dev, o browser pode servir o `index.html` antigo do cache HTTP, fazendo o usuário precisar de Ctrl+Shift+R para ver a versão atualizada — sintoma do "loop de login" (bundle anterior ao PR #37 que remontava o AuthProvider a cada rota).

Adiciona meta tags `Cache-Control: no-cache, no-store, must-revalidate` no `<head>` do `index.html`. O browser sempre buscará o HTML do servidor; os assets compilados com hash no nome continuam cacheados normalmente (sem impacto de performance).

## Plano de teste
- [ ] Após deploy, acessar a aplicação em aba normal (não anônima) → login funciona sem loop
- [ ] Após novo deploy, recarregar sem Ctrl+Shift+R → nova versão é carregada automaticamente

🤖 Generated with [Claude Code](https://claude.ai/claude-code)