### PR TITLE
fix: Total Pago acumula + erro PGRST201 na aba Frequencia

### DIFF
--- a/src/components/AthleteRegistrationCard.tsx
+++ b/src/components/AthleteRegistrationCard.tsx
@@ -84,6 +84,7 @@ export function AthleteRegistrationCard({
     handleAmountBlur
   } = usePaymentHandlers({
     athleteId: registration.id,
+    eventId: effectiveEventId ?? '',
     paymentData,
     refetchPayment
   });

--- a/src/components/athlete-card/hooks/usePaymentHandlers.ts
+++ b/src/components/athlete-card/hooks/usePaymentHandlers.ts
@@ -5,11 +5,12 @@ import { toast } from 'sonner';
 
 interface UsePaymentHandlersProps {
   athleteId: string;
+  eventId: string;
   paymentData: any;
   refetchPayment: () => Promise<any>;
 }
 
-export const usePaymentHandlers = ({ athleteId, paymentData, refetchPayment }: UsePaymentHandlersProps) => {
+export const usePaymentHandlers = ({ athleteId, eventId, paymentData, refetchPayment }: UsePaymentHandlersProps) => {
   const [isUpdatingAmount, setIsUpdatingAmount] = useState(false);
   const [localInputAmount, setLocalInputAmount] = useState<string>('');
 
@@ -20,7 +21,7 @@ export const usePaymentHandlers = ({ athleteId, paymentData, refetchPayment }: U
 
   const handleSaveAmount = async () => {
     if (!localInputAmount || isUpdatingAmount) return;
-    
+
     setIsUpdatingAmount(true);
     try {
       const numericValue = parseFloat(localInputAmount.replace(',', '.'));
@@ -29,7 +30,7 @@ export const usePaymentHandlers = ({ athleteId, paymentData, refetchPayment }: U
         return;
       }
 
-      await updatePaymentAmount(athleteId, numericValue);
+      await updatePaymentAmount(athleteId, numericValue, eventId);
       await refetchPayment();
       toast.success('Valor atualizado com sucesso!');
     } catch (error) {

--- a/src/components/dashboard/tabs/AthletesTab.tsx
+++ b/src/components/dashboard/tabs/AthletesTab.tsx
@@ -81,7 +81,7 @@ export function AthletesTab({
           }}
           onPaymentStatusChange={async (athleteId, status) => {
             try {
-              await updatePaymentStatus(athleteId, status);
+              await updatePaymentStatus(athleteId, status, currentEventId);
               toast.success("Status de pagamento atualizado com sucesso!");
               await queryClient.invalidateQueries({ 
                 queryKey: ['branch-analytics', currentEventId]

--- a/src/hooks/useOrganizerAttendanceReport.ts
+++ b/src/hooks/useOrganizerAttendanceReport.ts
@@ -86,7 +86,7 @@ export function useOrganizerAttendanceReport(eventId: string | null) {
           atleta_id,
           modalidade_id,
           data_inscricao,
-          usuarios!inner (
+          usuarios!inscricoes_modalidades_atleta_id_fkey (
             id,
             nome_completo,
             numero_documento

--- a/src/lib/api/payments.ts
+++ b/src/lib/api/payments.ts
@@ -3,49 +3,35 @@ import { supabase } from '../supabase';
 
 export const updatePaymentAmount = async (
   athleteId: string,
-  amount: number
+  amount: number,
+  eventId: string
 ): Promise<void> => {
-  console.log('Updating payment amount:', { athleteId, amount });
-  
-  try {
-    const { error } = await supabase
-      .from('pagamentos')
-      .update({ valor: amount })
-      .eq('atleta_id', athleteId);
+  const { error } = await supabase
+    .from('pagamentos')
+    .update({ valor: amount })
+    .eq('atleta_id', athleteId)
+    .eq('evento_id', eventId);
 
-    if (error) {
-      console.error('Error updating payment amount:', error);
-      throw new Error(error.message);
-    }
-
-    return Promise.resolve();
-  } catch (error) {
-    console.error('Error in updatePaymentAmount:', error);
-    throw error;
+  if (error) {
+    console.error('Error updating payment amount:', error);
+    throw new Error(error.message);
   }
 };
 
 export const updatePaymentStatus = async (
   athleteId: string,
-  status: string
+  status: string,
+  eventId: string
 ): Promise<void> => {
-  console.log('Updating payment status:', { athleteId, status });
-  
-  try {
-    const { error } = await supabase
-      .rpc('atualizar_status_pagamento', {
-        p_atleta_id: athleteId,
-        p_novo_status: status
-      });
+  const { error } = await supabase
+    .rpc('atualizar_status_pagamento', {
+      p_atleta_id: athleteId,
+      p_novo_status: status,
+      p_evento_id: eventId,
+    });
 
-    if (error) {
-      console.error('Error updating payment status:', error);
-      throw new Error(error.message);
-    }
-
-    return Promise.resolve();
-  } catch (error) {
-    console.error('Error in updatePaymentStatus:', error);
-    throw error;
+  if (error) {
+    console.error('Error updating payment status:', error);
+    throw new Error(error.message);
   }
 };

--- a/supabase/migrations/20260624_fix_atualizar_status_pagamento_evento_id.sql
+++ b/supabase/migrations/20260624_fix_atualizar_status_pagamento_evento_id.sql
@@ -1,0 +1,24 @@
+-- Adiciona filtro por evento_id à função atualizar_status_pagamento.
+-- Sem esse filtro, confirmar pagamento em um evento confirmava TODOS os eventos do atleta.
+
+CREATE OR REPLACE FUNCTION public.atualizar_status_pagamento(
+  p_atleta_id uuid,
+  p_novo_status text,
+  p_evento_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE public.pagamentos
+  SET
+    status = p_novo_status,
+    data_validacao = CASE
+      WHEN p_novo_status = 'confirmado' THEN NOW()
+      ELSE NULL
+    END
+  WHERE atleta_id = p_atleta_id
+    AND evento_id = p_evento_id;
+END;
+$$;


### PR DESCRIPTION
## Problema

Dois bugs corrigidos neste PR:

### 1. Total Pago acumula a cada confirmação (Item 3)

atualizar_status_pagamento nao tinha filtro por evento_id: confirmar pagamento de atleta em multiplos eventos atualizava TODOS. Idem updatePaymentAmount.

### 2. Aba Frequencia: erro PGRST201 (Item 2)

inscricoes_modalidades tem mais de uma FK para usuarios. O embed usuarios!inner era ambiguo. Precisava especificar a constraint correta.

## Solucao

- atualizar_status_pagamento (banco): novo parametro p_evento_id; WHERE inclui AND evento_id = p_evento_id
- payments.ts: updatePaymentStatus e updatePaymentAmount recebem e passam eventId
- AthletesTab.tsx: passa currentEventId para updatePaymentStatus
- usePaymentHandlers.ts: recebe eventId e repassa para updatePaymentAmount
- AthleteRegistrationCard.tsx: passa effectiveEventId para usePaymentHandlers
- useOrganizerAttendanceReport.ts: usuarios!inscricoes_modalidades_atleta_id_fkey desambigua o embed

## Migracao SQL obrigatoria

Executar no SQL Editor de sb.nova-acropole.org.br ANTES de testar:
supabase/migrations/20260624_fix_atualizar_status_pagamento_evento_id.sql

## Verificacao
- [ ] Total Pago: confirmar pag. atleta aumenta apenas 1x
- [ ] Alternar confirmado/pendente/confirmado mantem Total Pago correto
- [ ] Aba Frequencia carrega sem PGRST201
- [ ] npx tsc --noEmit sem erros (ja validado)