### PR TITLE
fix: aceita preposicoes em nomes no cadastro

### DIFF
--- a/src/components/auth/types/form-types.ts
+++ b/src/components/auth/types/form-types.ts
@@ -6,10 +6,8 @@ export type NationalityType = 'BRASILEIRO' | 'ESTRANGEIRO';
 
 export const createRegisterSchema = (t: (key: string) => string) => z.object({
   nome: z.string().refine((val) => {
-    // At least 2 words, each 3+ letters.
     const parts = val.trim().split(/\s+/);
-    if (parts.length < 2) return false;
-    return parts.every(p => p.length >= 3);
+    return parts.filter(p => p.length >= 3).length >= 2;
   }, t('validation.nameMin')),
   email: z.string().email(t('validation.emailInvalid')),
   ddi: z.string().min(1, t('validation.required')),


### PR DESCRIPTION
Validacao de nome completo rejeitava preposicoes como 'de', 'da', 'do', 'e' (menos de 3 letras). Antes: parts.every(p => p.length >= 3). Agora: pelo menos 2 palavras com 3+ letras, ignorando conectivos. Exemplo: 'Mauro Azeredo de Lima' passa normalmente.