### PR TITLE
fix: lista de atletas reflete status real + click-through nos cards de status

### DIFF
--- a/src/components/AthleteRegistrationCard.tsx
+++ b/src/components/AthleteRegistrationCard.tsx
@@ -104,6 +104,8 @@ export function AthleteRegistrationCard({
         return 'bg-warning-background text-warning-foreground border-warning/20';
       case 'cancelado':
         return 'bg-destructive/10 text-destructive-foreground border-destructive/20';
+      case 'isento':
+        return 'bg-sky-50 text-sky-700 border-sky-200';
       default:
         return 'bg-neutral-background text-neutral-foreground border-neutral/20';
     }
@@ -117,6 +119,8 @@ export function AthleteRegistrationCard({
         return 'border-l-4 border-l-warning bg-warning-background/50';
       case 'cancelado':
         return 'border-l-4 border-l-destructive bg-destructive/5';
+      case 'isento':
+        return 'border-l-4 border-l-sky-500 bg-sky-50/50';
       default:
         return 'border-l-4 border-l-neutral bg-neutral-background/50';
     }

--- a/src/components/DelegationDashboard.tsx
+++ b/src/components/DelegationDashboard.tsx
@@ -29,6 +29,12 @@ export default function DelegationDashboard() {
   const [paymentStatusFilter, setPaymentStatusFilter] = useState("all");
   const [activeTab, setActiveTab] = useState("statistics");
 
+  // Clicar num card de status nas Estatísticas abre a aba Atletas já filtrada
+  const handleStatusCardClick = (status: string) => {
+    setPaymentStatusFilter(status);
+    setActiveTab("athletes");
+  };
+
   // Check if the user is a delegation representative
   const isDelegationRep = user?.papeis?.some(role => role.codigo === 'RDD') || false;
   const isOrganizer = user?.papeis?.some(role => role.codigo === 'ORG') || false;
@@ -84,6 +90,7 @@ export default function DelegationDashboard() {
           <StatisticsTab
             data={branchAnalytics}
             currentBranchId={primaryFilialId}
+            onStatusClick={handleStatusCardClick}
           />
         );
 

--- a/src/components/OrganizerDashboard.tsx
+++ b/src/components/OrganizerDashboard.tsx
@@ -30,6 +30,12 @@ export default function OrganizerDashboard() {
   const [branchFilter, setBranchFilter] = useState("all");
   const [paymentStatusFilter, setPaymentStatusFilter] = useState("all");
 
+  // Clicar num card de status nas Estatísticas abre a aba Atletas já filtrada
+  const handleStatusCardClick = (status: string) => {
+    setPaymentStatusFilter(status);
+    setActiveTab("athletes");
+  };
+
   const {
     isRefreshing,
     branches,
@@ -60,7 +66,7 @@ export default function OrganizerDashboard() {
             description="Não encontramos dados de análise para exibir neste momento"
           />;
         }
-        return <StatisticsTab data={branchAnalytics} />;
+        return <StatisticsTab data={branchAnalytics} onStatusClick={handleStatusCardClick} />;
 
       case "athletes":
         if (isLoading.athletes || isLoading.branches) {

--- a/src/components/athlete-card/hooks/useExemptionStatus.ts
+++ b/src/components/athlete-card/hooks/useExemptionStatus.ts
@@ -69,7 +69,7 @@ export const useExemptionStatus = ({
       // First, check if payment record exists
       const { data: existingPayment, error: checkError } = await supabase
         .from('pagamentos')
-        .select('id, isento, valor, status')
+        .select('id, isento, valor, status, taxas_inscricao ( valor )')
         .eq('atleta_id', userId)
         .eq('evento_id', eventId)
         .single();
@@ -87,11 +87,14 @@ export const useExemptionStatus = ({
         throw new Error('Registro de pagamento não encontrado. O pagamento deve ser criado primeiro.');
       }
 
+      // Ao desmarcar, o valor atual já foi zerado pela isenção — restaurar da taxa vinculada
+      const taxaValor = (existingPayment.taxas_inscricao as any)?.valor ?? existingPayment.valor;
+
       // Update exemption status in pagamentos table
-      const updateData: any = { 
+      const updateData: any = {
         isento: checked,
         status: checked ? 'isento' : 'pendente', // Set status to "isento" when exempt, "pendente" when not
-        valor: checked ? 0 : existingPayment.valor // Set value to 0 when exempt, restore original when not
+        valor: checked ? 0 : taxaValor
       };
 
       console.log('Updating payment with data:', updateData);

--- a/src/components/athlete-card/utils/statusColors.ts
+++ b/src/components/athlete-card/utils/statusColors.ts
@@ -6,6 +6,8 @@ export function getStatusBadgeStyle(status: string): string {
       return 'bg-warning-background text-warning-foreground border-warning/20';
     case 'cancelado':
       return 'bg-destructive/10 text-destructive-foreground border-destructive/20';
+    case 'isento':
+      return 'bg-sky-50 text-sky-700 border-sky-200';
     default:
       return 'bg-neutral-background text-neutral-foreground border-neutral/20';
   }
@@ -19,6 +21,8 @@ export function getStatusBorderColor(status: string): string {
       return 'border-l-4 border-l-warning bg-warning-background/50';
     case 'cancelado':
       return 'border-l-4 border-l-destructive bg-destructive/5';
+    case 'isento':
+      return 'border-l-4 border-l-sky-500 bg-sky-50/50';
     default:
       return 'border-l-4 border-l-neutral bg-neutral-background/50';
   }

--- a/src/components/dashboard/AthleteFilters.tsx
+++ b/src/components/dashboard/AthleteFilters.tsx
@@ -81,6 +81,7 @@ export function AthleteFilters({
               <SelectItem value="all">Todos os status</SelectItem>
               <SelectItem value="confirmado">Confirmado</SelectItem>
               <SelectItem value="pendente">Pendente</SelectItem>
+              <SelectItem value="isento">Isento</SelectItem>
               <SelectItem value="cancelado">Cancelado</SelectItem>
             </SelectContent>
           </Select>

--- a/src/components/dashboard/charts/PaymentStatusBarChart.tsx
+++ b/src/components/dashboard/charts/PaymentStatusBarChart.tsx
@@ -14,11 +14,14 @@ interface PaymentStatusData {
   isentoPct: number;
 }
 
+export type PaymentStatusKey = 'confirmado' | 'pendente' | 'isento' | 'cancelado';
+
 interface PaymentStatusBarChartProps {
   data: PaymentStatusData[];
   chartConfig?: any;
   title?: string;
   description?: string;
+  onStatusClick?: (status: PaymentStatusKey) => void;
 }
 
 const STATUS = [
@@ -28,7 +31,7 @@ const STATUS = [
   { key: 'cancelado'  as const, pctKey: 'canceladoPct'  as const, label: 'Cancelado',  color: 'bg-red-400',    text: 'text-red-700',    bg: 'bg-red-50',    border: 'border-red-200',    Icon: XCircle },
 ] as const;
 
-export function PaymentStatusBarChart({ data }: PaymentStatusBarChartProps) {
+export function PaymentStatusBarChart({ data, onStatusClick }: PaymentStatusBarChartProps) {
   if (!data || data.length === 0) return null;
 
   const d = data[0];
@@ -44,16 +47,38 @@ export function PaymentStatusBarChart({ data }: PaymentStatusBarChartProps) {
         visible.length === 2 ? "grid-cols-2" :
         visible.length === 3 ? "grid-cols-3" : "grid-cols-2 sm:grid-cols-4"
       )}>
-        {visible.map(s => (
-          <div key={s.key} className={cn("rounded-xl border p-3 flex items-center gap-3", s.bg, s.border)}>
-            <s.Icon className={cn("h-5 w-5 flex-shrink-0", s.text)} />
-            <div className="min-w-0">
-              <p className={cn("text-xl font-bold leading-none", s.text)}>{d[s.key]}</p>
-              <p className={cn("text-xs mt-0.5 font-medium", s.text)}>{s.label}</p>
-              <p className="text-[11px] text-muted-foreground">{d[s.pctKey].toFixed(0)}%</p>
+        {visible.map(s => {
+          const content = (
+            <>
+              <s.Icon className={cn("h-5 w-5 flex-shrink-0", s.text)} />
+              <div className="min-w-0 text-left">
+                <p className={cn("text-xl font-bold leading-none", s.text)}>{d[s.key]}</p>
+                <p className={cn("text-xs mt-0.5 font-medium", s.text)}>{s.label}</p>
+                <p className="text-[11px] text-muted-foreground">{d[s.pctKey].toFixed(0)}%</p>
+              </div>
+            </>
+          );
+
+          return onStatusClick ? (
+            <button
+              key={s.key}
+              type="button"
+              onClick={() => onStatusClick(s.key)}
+              title={`Ver atletas com pagamento ${s.label.toLowerCase()}`}
+              className={cn(
+                "rounded-xl border p-3 flex items-center gap-3 cursor-pointer transition-shadow",
+                "hover:shadow-md hover:ring-2 hover:ring-offset-1 hover:ring-current focus-visible:ring-2",
+                s.bg, s.border
+              )}
+            >
+              {content}
+            </button>
+          ) : (
+            <div key={s.key} className={cn("rounded-xl border p-3 flex items-center gap-3", s.bg, s.border)}>
+              {content}
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Barra segmentada */}

--- a/src/components/dashboard/tabs/StatisticsTab.tsx
+++ b/src/components/dashboard/tabs/StatisticsTab.tsx
@@ -1,7 +1,7 @@
 
 import { BranchAnalytics } from "@/types/api";
 import { SummaryCards } from "../charts/SummaryCards";
-import { PaymentStatusBarChart } from "../charts/PaymentStatusBarChart";
+import { PaymentStatusBarChart, PaymentStatusKey } from "../charts/PaymentStatusBarChart";
 import { BranchRegistrationsChart } from "../charts/BranchRegistrationsChart";
 import { ModalitiesChart } from "../charts/ModalitiesChart";
 import { transformPaymentStatusData, transformBranchRegistrationsData } from "../charts/dataTransformers";
@@ -9,6 +9,7 @@ import { transformPaymentStatusData, transformBranchRegistrationsData } from "..
 interface StatisticsTabProps {
   data: BranchAnalytics[];
   currentBranchId?: string;
+  onStatusClick?: (status: PaymentStatusKey) => void;
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
@@ -20,7 +21,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
-export function StatisticsTab({ data, currentBranchId }: StatisticsTabProps) {
+export function StatisticsTab({ data, currentBranchId, onStatusClick }: StatisticsTabProps) {
   if (!data || data.length === 0) {
     return (
       <p className="text-center py-16 text-sm text-muted-foreground">
@@ -84,7 +85,7 @@ export function StatisticsTab({ data, currentBranchId }: StatisticsTabProps) {
 
       {/* Payment status */}
       <Section title="Status de Inscrições">
-        <PaymentStatusBarChart data={paymentData} />
+        <PaymentStatusBarChart data={paymentData} onStatusClick={onStatusClick} />
       </Section>
 
       {/* Modalities */}

--- a/src/lib/api/athletes.ts
+++ b/src/lib/api/athletes.ts
@@ -45,7 +45,7 @@ export const fetchAthleteManagement = async (filialIds: string[] | undefined, ev
     if (data) {
       data.forEach(record => {
         if (!athletesMap.has(record.atleta_id)) {
-          const paymentStatus = record.isento ? 'confirmado' : (record.status_pagamento || 'pendente');
+          const paymentStatus = record.status_pagamento || 'pendente';
 
           athletesMap.set(record.atleta_id, {
             id: record.atleta_id,
@@ -59,7 +59,7 @@ export const fetchAthleteManagement = async (filialIds: string[] | undefined, ev
             status_confirmacao: record.status_confirmacao,
             filial_id: record.filial_id,
             filial_nome: record.filial_nome,
-            status_pagamento: paymentStatus as 'pendente' | 'confirmado' | 'cancelado',
+            status_pagamento: paymentStatus as 'pendente' | 'confirmado' | 'cancelado' | 'isento',
             usuario_registrador_id: record.usuario_registrador_id,
             registrador_nome: record.registrador_nome,
             registrador_email: record.registrador_email,
@@ -74,7 +74,7 @@ export const fetchAthleteManagement = async (filialIds: string[] | undefined, ev
           const modalityExists = athlete.modalidades.some(m => m.id === record.inscricao_id);
 
           if (!modalityExists && record.inscricao_id) {
-            const modalityStatus = record.isento ? 'confirmado' : (record.status_inscricao || 'pendente');
+            const modalityStatus = record.status_inscricao || 'pendente';
 
             athlete.modalidades.push({
               id: record.inscricao_id.toString(),
@@ -188,7 +188,7 @@ export const fetchAthleteManagement = async (filialIds: string[] | undefined, ev
             registradorInfo = registrador;
           }
 
-          const paymentStatus = eventReg.isento ? 'confirmado' : (eventReg.status_pagamento || 'pendente');
+          const paymentStatus = eventReg.status_pagamento || 'pendente';
 
           athletesMap.set(eventReg.usuario_id, {
             id: athleteData.id,
@@ -202,7 +202,7 @@ export const fetchAthleteManagement = async (filialIds: string[] | undefined, ev
             status_confirmacao: eventReg.status_confirmacao || false,
             filial_id: athleteData.filial_id,
             filial_nome: filialData?.nome || null,
-            status_pagamento: paymentStatus as 'pendente' | 'confirmado' | 'cancelado',
+            status_pagamento: paymentStatus as 'pendente' | 'confirmado' | 'cancelado' | 'isento',
             usuario_registrador_id: eventReg.usuario_registrador_id,
             registrador_nome: registradorInfo?.nome_completo || null,
             registrador_email: registradorInfo?.email || null,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -21,7 +21,7 @@ export interface AthleteManagement {
   status_confirmacao: boolean;
   filial_id: string;
   filial_nome: string;
-  status_pagamento: 'pendente' | 'confirmado' | 'cancelado';
+  status_pagamento: 'pendente' | 'confirmado' | 'cancelado' | 'isento';
   usuario_registrador_id?: string;
   registrador_nome?: string;
   registrador_email?: string;

--- a/supabase/migrations/20260702_fix_pagamentos_isento_flag.sql
+++ b/supabase/migrations/20260702_fix_pagamentos_isento_flag.sql
@@ -1,0 +1,31 @@
+-- Limpeza de flags de isenção dessincronizadas no evento 1a9e71ee (decisão do
+-- organizador: ninguém é isento nesse evento, todos pagantes).
+--
+-- Contexto: 9 registros tinham isento=true com status <> 'isento' (dado legado);
+-- a lista de atletas tratava a flag como "Confirmado" e escondia 8 pendentes.
+-- Outros 2 registros estavam com status='isento' e valor zerado.
+--
+-- EXECUTAR MANUALMENTE no SQL Editor de sb.nova-acropole.org.br.
+
+-- 1. Flags órfãs (8 pendentes + 1 confirmado): limpa a flag, mantém o status
+UPDATE public.pagamentos
+SET isento = false
+WHERE evento_id = '1a9e71ee-5127-4d65-a83e-2f058446286b'
+  AND isento = true
+  AND status <> 'isento';
+
+-- 2. Os 2 com status='isento': voltam a pendente com valor restaurado da taxa
+UPDATE public.pagamentos p
+SET isento = false,
+    status = 'pendente',
+    valor = t.valor
+FROM public.taxas_inscricao t
+WHERE t.id = p.taxa_inscricao_id
+  AND p.evento_id = '1a9e71ee-5127-4d65-a83e-2f058446286b'
+  AND p.status = 'isento';
+
+-- Conferência: deve retornar 12 confirmado / 13 pendente e nenhum isento
+SELECT status, count(*), sum(valor) AS valor_total
+FROM public.pagamentos
+WHERE evento_id = '1a9e71ee-5127-4d65-a83e-2f058446286b'
+GROUP BY status;


### PR DESCRIPTION
## Problema

'Status de Inscricoes' (Estatisticas) mostrava 11 pendentes, mas a lista Gerenciamento de Atletas filtrada por Pendente mostrava so 3.

## Causa raiz (verificada direto no banco via REST)

O grafico esta CERTO (pagamentos.status do evento: 12 confirmados / 11 pendentes / 2 isentos). O problema e a LISTA: em fetchAthleteManagement, a flag booleana pagamentos.isento sobrepunha o status real ('isento flag -> Confirmado'). No banco ha 9 registros legados com isento=true mas status <> 'isento' - 8 pendentes viravam 'Confirmado' na lista e sumiam do filtro Pendente.

## Solucao

**Codigo:**
- athletes.ts: status exibido = status real de pagamento (remove override da flag nos 3 pontos, incl. status de modalidade)
- 'isento' vira status de primeira classe: tipo AthleteManagement, opcao 'Isento' no filtro, badge sky nos cards
- useExemptionStatus: ao desmarcar isencao, restaura o valor da taxa vinculada (bug: 'restaurava' o valor ja zerado, ficava 0 para sempre)
- Feature: cards Confirmado/Pendente/Isento/Cancelado do grafico agora sao clicaveis e abrem a aba Atletas com o filtro de status aplicado (Organizador e Delegacao)

**Dados (migracao manual — decisao do organizador: ninguem e isento nesse evento):**
- supabase/migrations/20260702_fix_pagamentos_isento_flag.sql
- Limpa as 9 flags orfas (mantem status) e converte os 2 status='isento' para pendente com valor restaurado da taxa
- Resultado esperado: 12 confirmados / 13 pendentes / 0 isentos (grafico e lista batem)

## Verificacao
- [x] npx tsc --noEmit sem erros
- [ ] Rodar migracao no SQL Editor de sb.nova-acropole.org.br
- [ ] Grafico e filtro Pendente mostram os mesmos 13 atletas
- [ ] Clicar no card Pendente abre a aba Atletas filtrada
- [ ] Marcar/desmarcar isencao alterna status e valor corretamente