### PR TITLE
feat: Inscricoes por Modalidade com barras empilhadas por status da inscricao

### DIFF
--- a/src/components/dashboard/charts/ModalitiesChart.tsx
+++ b/src/components/dashboard/charts/ModalitiesChart.tsx
@@ -1,6 +1,6 @@
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
-  ResponsiveContainer, Cell, LabelList
+  ResponsiveContainer, LabelList
 } from "recharts";
 import { BranchAnalytics } from "@/types/api";
 
@@ -8,67 +8,113 @@ interface Props {
   data: BranchAnalytics[];
 }
 
-const BRAND = "#009B40";
+const STATUS_SEGMENTS = [
+  { key: 'confirmado', label: 'Confirmada', color: '#10b981' },
+  { key: 'pendente',   label: 'Pendente',   color: '#f59e0b' },
+  { key: 'cancelado',  label: 'Cancelada',  color: '#f87171' },
+  { key: 'rejeitado',  label: 'Rejeitada',  color: '#9ca3af' },
+] as const;
+
+type StatusKey = typeof STATUS_SEGMENTS[number]['key'];
+
+interface ModalityRow {
+  name: string;
+  confirmado: number;
+  pendente: number;
+  cancelado: number;
+  rejeitado: number;
+  total: number;
+}
 
 function CustomTooltip({ active, payload, label }: any) {
   if (!active || !payload?.length) return null;
+  const row: ModalityRow = payload[0].payload;
   return (
     <div className="rounded-lg border bg-card px-3 py-2 shadow-md text-sm">
       <p className="font-semibold text-foreground mb-1">{label}</p>
-      <p className="text-muted-foreground">{payload[0].value} inscritos</p>
+      {STATUS_SEGMENTS.filter(s => row[s.key] > 0).map(s => (
+        <p key={s.key} className="text-muted-foreground flex items-center gap-1.5">
+          <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: s.color }} />
+          {s.label}: {row[s.key]}
+        </p>
+      ))}
+      <p className="text-foreground font-medium mt-1">Total: {row.total}</p>
     </div>
   );
 }
 
 export function ModalitiesChart({ data }: Props) {
   // modalidades_populares is event-wide and repeated identically in every branch
-  // row, with one entry per (modalidade × filial × status_pagamento) — so read
+  // row, with one entry per (modalidade × filial × status da inscrição) — so read
   // one row, keep only the branches being displayed, and SUM the slices.
   const selectedBranches = new Set(data.map(b => b.filial));
   const source = data[0]?.modalidades_populares || [];
-  const map = new Map<string, number>();
+
+  const map = new Map<string, ModalityRow>();
   source.forEach(m => {
     if (m.filial && !selectedBranches.has(m.filial)) return;
-    map.set(m.modalidade, (map.get(m.modalidade) ?? 0) + m.total_inscritos);
+    // status_pagamento fallback keeps the chart working until the view migration runs
+    const status = (m.status_inscricao ?? m.status_pagamento ?? 'pendente') as StatusKey;
+    if (!map.has(m.modalidade)) {
+      map.set(m.modalidade, { name: m.modalidade, confirmado: 0, pendente: 0, cancelado: 0, rejeitado: 0, total: 0 });
+    }
+    const row = map.get(m.modalidade)!;
+    if (status in row) {
+      row[status] += m.total_inscritos;
+    }
+    row.total += m.total_inscritos;
   });
 
   if (map.size === 0) return null;
 
-  const sorted = Array.from(map.entries())
-    .map(([name, value]) => ({ name, value }))
-    .sort((a, b) => b.value - a.value);
+  const sorted = Array.from(map.values()).sort((a, b) => b.total - a.total);
+  const visibleSegments = STATUS_SEGMENTS.filter(s => sorted.some(row => row[s.key] > 0));
+  const lastSegmentKey = visibleSegments[visibleSegments.length - 1]?.key;
 
   const chartHeight = sorted.length * 36 + 20;
 
   return (
-    <ResponsiveContainer width="100%" height={chartHeight}>
-      <BarChart
-        data={sorted}
-        layout="vertical"
-        margin={{ top: 0, right: 48, left: 0, bottom: 0 }}
-      >
-        <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="#f0f0f0" />
-        <XAxis type="number" hide />
-        <YAxis
-          type="category"
-          dataKey="name"
-          width={140}
-          tick={{ fontSize: 12, fill: '#555' }}
-          tickLine={false}
-          axisLine={false}
-        />
-        <Tooltip content={<CustomTooltip />} cursor={{ fill: '#e6f7ee' }} />
-        <Bar dataKey="value" radius={[0, 6, 6, 0]} barSize={20}>
-          {sorted.map((_, i) => (
-            <Cell key={i} fill={BRAND} opacity={Math.max(0.4, 1 - i * 0.055)} />
-          ))}
-          <LabelList
-            dataKey="value"
-            position="right"
-            style={{ fontSize: 12, fontWeight: 600, fill: '#555' }}
+    <div className="space-y-2">
+      <ResponsiveContainer width="100%" height={chartHeight}>
+        <BarChart
+          data={sorted}
+          layout="vertical"
+          margin={{ top: 0, right: 48, left: 0, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="#f0f0f0" />
+          <XAxis type="number" hide />
+          <YAxis
+            type="category"
+            dataKey="name"
+            width={140}
+            tick={{ fontSize: 12, fill: '#555' }}
+            tickLine={false}
+            axisLine={false}
           />
-        </Bar>
-      </BarChart>
-    </ResponsiveContainer>
+          <Tooltip content={<CustomTooltip />} cursor={{ fill: '#e6f7ee' }} />
+          {visibleSegments.map(s => (
+            <Bar key={s.key} dataKey={s.key} stackId="status" name={s.label} fill={s.color} barSize={20}>
+              {s.key === lastSegmentKey && (
+                <LabelList
+                  dataKey="total"
+                  position="right"
+                  style={{ fontSize: 12, fontWeight: 600, fill: '#555' }}
+                />
+              )}
+            </Bar>
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+
+      {/* Legenda */}
+      <div className="flex flex-wrap gap-3 text-[11px] text-muted-foreground pl-1">
+        {visibleSegments.map(s => (
+          <span key={s.key} className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: s.color }} />
+            {s.label}
+          </span>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -51,6 +51,7 @@ export interface Branch {
 export interface ModalidadePopular {
   modalidade: string;
   total_inscritos: number;
+  status_inscricao?: string;
   status_pagamento?: string;
   filial?: string;
 }

--- a/supabase/migrations/20260702_modalidades_por_status_inscricao.sql
+++ b/supabase/migrations/20260702_modalidades_por_status_inscricao.sql
@@ -1,0 +1,109 @@
+-- "Inscrições por Modalidade" passa a segmentar por status da INSCRIÇÃO.
+--
+-- Mudanças no CTE modality_data (restante da view intacto):
+--   1. Remove o filtro im.status='confirmado' — o gráfico agora mostra o total
+--      real de inscrições por modalidade, empilhado por status.
+--   2. Remove o LEFT JOIN pagamentos (não é mais necessário) e expõe
+--      im.status AS status_inscricao.
+--   3. modalidades_populares: chave 'status_inscricao' no lugar de
+--      'status_pagamento'.
+--
+-- EXECUTAR MANUALMENTE no SQL Editor de sb.nova-acropole.org.br.
+
+CREATE OR REPLACE VIEW public.vw_analytics_inscricoes AS
+WITH all_events AS (
+         SELECT eventos.id AS evento_id
+           FROM eventos
+        ), all_branches AS (
+         SELECT filiais.id AS filial_id,
+            filiais.nome AS filial
+           FROM filiais
+        ), event_branch_combinations AS (
+         SELECT ae.evento_id,
+            ab.filial_id,
+            ab.filial
+           FROM all_events ae
+             CROSS JOIN all_branches ab
+        ), registration_data AS (
+         SELECT u.filial_id,
+            f.nome AS filial,
+            p.evento_id,
+            p.atleta_id,
+            p.status AS status_pagamento,
+            p.valor
+           FROM pagamentos p
+             JOIN usuarios u ON p.atleta_id = u.id
+             JOIN filiais f ON u.filial_id = f.id
+          WHERE p.status = ANY (ARRAY['confirmado'::text, 'pendente'::text, 'cancelado'::text, 'isento'::text])
+        ), modality_data AS (
+         SELECT u.filial_id,
+            f.nome AS filial,
+            im.evento_id,
+            im.atleta_id,
+            im.modalidade_id,
+            m.nome AS modalidade_nome,
+            im.status AS status_inscricao
+           FROM inscricoes_modalidades im
+             JOIN usuarios u ON im.atleta_id = u.id
+             JOIN filiais f ON u.filial_id = f.id
+             LEFT JOIN modalidades m ON m.id = im.modalidade_id
+        ), branch_payment_status AS (
+         SELECT ebc_1.evento_id,
+            ebc_1.filial_id,
+            ebc_1.filial,
+            COALESCE(rd.status_pagamento, 'pendente'::text) AS status_pagamento,
+            count(DISTINCT rd.atleta_id) AS quantidade
+           FROM event_branch_combinations ebc_1
+             LEFT JOIN registration_data rd ON ebc_1.evento_id = rd.evento_id AND ebc_1.filial_id = rd.filial_id
+          GROUP BY ebc_1.evento_id, ebc_1.filial_id, ebc_1.filial, (COALESCE(rd.status_pagamento, 'pendente'::text))
+        ), branch_modality_counts AS (
+         SELECT ebc_1.evento_id,
+            ebc_1.filial_id,
+            ebc_1.filial,
+            md.modalidade_nome,
+            COALESCE(md.status_inscricao, 'pendente'::text) AS status_inscricao,
+            count(DISTINCT md.atleta_id) AS total_inscritos
+           FROM event_branch_combinations ebc_1
+             LEFT JOIN modality_data md ON ebc_1.evento_id = md.evento_id AND ebc_1.filial_id = md.filial_id
+          WHERE md.modalidade_nome IS NOT NULL
+          GROUP BY ebc_1.evento_id, ebc_1.filial_id, ebc_1.filial, md.modalidade_nome, (COALESCE(md.status_inscricao, 'pendente'::text))
+        ), branch_rankings AS (
+         SELECT rf.evento_id,
+            rf.filial_id,
+            COALESCE(rf.total_pontos, 0::numeric) AS total_pontos
+           FROM ranking_filiais rf
+        )
+ SELECT ebc.filial_id,
+    ebc.filial,
+    ebc.evento_id,
+    COALESCE(( SELECT sum(bps.quantidade) AS sum
+           FROM branch_payment_status bps
+          WHERE bps.filial_id = ebc.filial_id AND bps.evento_id = ebc.evento_id AND (bps.status_pagamento = ANY (ARRAY['confirmado'::text, 'pendente'::text, 'cancelado'::text, 'isento'::text]))), 0::numeric) AS total_inscritos_geral,
+    COALESCE(( SELECT count(*) AS count
+           FROM modality_data md
+          WHERE md.filial_id = ebc.filial_id AND md.evento_id = ebc.evento_id), 0::bigint) AS total_inscritos_modalidades,
+    COALESCE(( SELECT sum(rd.valor) AS sum
+           FROM registration_data rd
+          WHERE rd.filial_id = ebc.filial_id AND rd.evento_id = ebc.evento_id AND rd.status_pagamento = 'confirmado'::text), 0::numeric) AS valor_total_pago,
+    COALESCE(( SELECT sum(rd.valor) AS sum
+           FROM registration_data rd
+          WHERE rd.filial_id = ebc.filial_id AND rd.evento_id = ebc.evento_id AND rd.status_pagamento = 'pendente'::text), 0::numeric) AS valor_total_pendente,
+    COALESCE(( SELECT jsonb_agg(jsonb_build_object('modalidade', bmc.modalidade_nome, 'status_inscricao', bmc.status_inscricao, 'total_inscritos', bmc.total_inscritos, 'filial', bmc.filial)) AS jsonb_agg
+           FROM branch_modality_counts bmc
+          WHERE bmc.evento_id = ebc.evento_id AND bmc.modalidade_nome IS NOT NULL), '[]'::jsonb) AS modalidades_populares,
+    COALESCE(( SELECT jsonb_agg(jsonb_build_object('status_pagamento', bps.status_pagamento, 'quantidade', bps.quantidade)) AS jsonb_agg
+           FROM branch_payment_status bps
+          WHERE bps.filial_id = ebc.filial_id AND bps.evento_id = ebc.evento_id), '[]'::jsonb) AS inscritos_por_status_pagamento,
+    COALESCE(( SELECT jsonb_agg(jsonb_build_object('status_pagamento', bps.status_pagamento, 'quantidade', bps.quantidade)) AS jsonb_agg
+           FROM branch_payment_status bps
+          WHERE bps.filial_id = ebc.filial_id AND bps.evento_id = ebc.evento_id), '[]'::jsonb) AS total_inscritos_por_status,
+    COALESCE(( SELECT jsonb_agg(jsonb_build_object('total_pontos', COALESCE(br.total_pontos, 0::numeric))) AS jsonb_agg
+           FROM branch_rankings br
+          WHERE br.filial_id = ebc.filial_id AND br.evento_id = ebc.evento_id), '[{"total_pontos": 0}]'::jsonb) AS ranking_filiais,
+    COALESCE(( SELECT jsonb_agg(jsonb_build_object('filial_nome', bps.filial, 'status_pagamento', bps.status_pagamento, 'quantidade', bps.quantidade)) AS jsonb_agg
+           FROM branch_payment_status bps
+          WHERE bps.evento_id = ebc.evento_id), '[]'::jsonb) AS registros_por_filial,
+    '[]'::jsonb AS atletas_por_categoria,
+    '[]'::jsonb AS media_pontuacao_por_modalidade
+   FROM event_branch_combinations ebc
+  GROUP BY ebc.filial_id, ebc.filial, ebc.evento_id;


### PR DESCRIPTION
## Contexto

O grafico 'Inscricoes por Modalidade' mostrava so um numero por modalidade e (na view atual) apenas inscricoes confirmadas. Dado real da Corrida: 10 inscricoes = 9 confirmadas + 1 pendente. O usuario pediu barras empilhadas por status com legenda para ver o total real.

Obs: o '4' visto em producao era o build anterior aos merges dos PRs #50/#51 (bug de sobrescrita mostrava so a ultima fatia). O click-through dos cards de status ja esta na main (PR #51) e entra no mesmo build.

## Mudancas

**ModalitiesChart.tsx (reescrito):**
- Barras horizontais EMPILHADAS por status da inscricao: Confirmada (verde), Pendente (ambar), Cancelada (vermelho), Rejeitada (cinza) - segmentos so aparecem quando ha dados
- Total da modalidade a direita da barra; tooltip com breakdown por status; legenda no rodape
- Mantem filtro por filiais exibidas (visao delegacao) e soma de fatias

**View (migracao manual 20260702_modalidades_por_status_inscricao.sql):**
- modality_data: remove filtro im.status='confirmado' e o LEFT JOIN pagamentos; expoe im.status AS status_inscricao
- modalidades_populares: fatias por (modalidade x filial x status_inscricao)

**Transicao:** fallback para status_pagamento mantem o grafico funcional ate a migracao rodar.

## Migracao SQL obrigatoria

Executar no SQL Editor de sb.nova-acropole.org.br:
supabase/migrations/20260702_modalidades_por_status_inscricao.sql

## Verificacao
- [x] npx tsc --noEmit sem erros
- [ ] Corrida = barra de 10 (9 Confirmada + 1 Pendente) com legenda
- [ ] Tiro com Arco = 7 (6 + 1 Cancelada); Arremesso = 3 (1+1+1)
- [ ] /delegacao identico (evento so tem PoA-Centro)