### PR TITLE
feat: isencao de atletas por ADM/ORG/RDD (justificativa + auditoria)

### DIFF
--- a/docs/PAPEIS_E_PERMISSOES.md
+++ b/docs/PAPEIS_E_PERMISSOES.md
@@ -1,0 +1,32 @@
+# Papéis e Permissões
+
+Os papéis de usuário vivem em `perfis_tipo.codigo` no banco. Cada usuário recebe um ou mais papéis **por evento** (tabela `papeis_usuarios` → `perfis` → `perfis_tipo`). No frontend, os papéis chegam em `useAuth().user.papeis` (array de `{ codigo, nome, descricao }`) e o padrão de verificação é:
+
+```ts
+const isAdmin = user?.papeis?.some(r => r.codigo === 'ADM');
+```
+
+## Códigos
+
+| Código | Papel | O que faz |
+|--------|-------|-----------|
+| **ADM** | Administrador | Acesso total ao evento: configuração, perfis, filiais, delegações. |
+| **ORG** | Organizador | Gestão geral do evento pelo dashboard `/organizador` (atletas, inscrições, estatísticas, chamadas). `ORE` é uma variante legada do mesmo papel. |
+| **RDD** | Representante de Delegação | Gerencia apenas atletas das filiais da **sua** delegação, pelo dashboard `/delegacao`. Escopo resolvido pela RPC `get_user_delegacao_filiais`. |
+| **ATL** | Atleta | Inscreve-se em modalidades, vê o próprio cronograma e status de pagamento. |
+| **PGR** | Responsável / Guardião | Usuário que cadastra e gerencia dependentes (menores). |
+| **JUZ** | Juiz | Lança pontuações nas modalidades de competição. |
+| **MST** / **MSTR** | Master | Acesso total ao sistema (multi-evento). Também sinalizado por `usuarios.is_master`. |
+| **FMON** / **FMO** | Filósofo Monitor | Registra chamadas/presenças das suas modalidades. |
+
+> Nota: `useUserRoleCheck.ts` referencia `'DEL'` para representante — é um resíduo sem uso real. O código canônico do Representante de Delegação é **RDD**.
+
+## Permissão de isenção de pagamento
+
+Marcar um atleta como **isento** (zera o valor do pagamento) é ação exclusiva de **ADM**, **ORG** e **RDD**:
+
+- **ADM / ORG** — podem isentar qualquer atleta do evento.
+- **RDD** — só pode isentar atletas das filiais da sua delegação.
+- **Atleta** — **não** pode se autoisentar.
+
+A concessão exige **justificativa** e registra **quem concedeu** (`pagamentos.isento_por`, `isento_justificativa`, `isento_em`), com trilha em `pagamentos_audit_log`. Toda a lógica e a checagem de permissão ficam na RPC `conceder_isencao` (`SECURITY DEFINER`), que valida o papel do chamador via `auth.uid()` — o gating no frontend é apenas de UX.

--- a/src/components/AthleteRegistrationCard.tsx
+++ b/src/components/AthleteRegistrationCard.tsx
@@ -16,6 +16,7 @@ import { usePaymentHandlers } from './athlete-card/hooks/usePaymentHandlers';
 import { EnrollAthleteDialog } from './athlete-card/EnrollAthleteDialog';
 import { EnrollmentType } from '@/hooks/useEnrollAthleteInModality';
 import { useAuth } from '@/contexts/AuthContext';
+import { useDelegacaoFiliais } from '@/hooks/useDelegacoes';
 import { UserPlus } from 'lucide-react';
 
 interface AthleteRegistrationCardProps {
@@ -49,6 +50,19 @@ export function AthleteRegistrationCard({
 
   const effectiveEventId = eventId || currentEventId;
 
+  // Quem pode conceder isenção: ADM/ORG (qualquer atleta) ou RDD (só da própria delegação).
+  // A RPC valida de novo no servidor; aqui é só UX.
+  const isAdminOrg = user?.papeis?.some(r => ['ADM', 'ORG', 'ORE'].includes(r.codigo)) ?? false;
+  const isDelegationRep = user?.papeis?.some(r => r.codigo === 'RDD') ?? false;
+  const { data: delegacaoFiliais } = useDelegacaoFiliais(
+    isDelegationRep ? user?.id : undefined,
+    isDelegationRep ? (effectiveEventId || undefined) : undefined
+  );
+  const canManageExemption =
+    !readOnly &&
+    (isAdminOrg || (isDelegationRep && !!registration.filial_id &&
+      (delegacaoFiliais ?? []).includes(registration.filial_id)));
+
   const {
     paymentData,
     refetchPayment,
@@ -56,10 +70,10 @@ export function AthleteRegistrationCard({
     isDependent
   } = useAthleteCardData(registration);
 
-  const { isExempt, isUpdatingExemption, handleExemptionChange } = useExemptionStatus({
+  const { isExempt, isUpdatingExemption, exemptionInfo, handleExemptionChange } = useExemptionStatus({
     userId: registration.id,
     eventId: registration.evento_id,
-    isCurrentUser,
+    canManage: canManageExemption,
     refetchPayment
   });
 
@@ -208,10 +222,11 @@ export function AthleteRegistrationCard({
           )}
 
           <ExemptionCheckbox
-            isCurrentUser={isCurrentUser}
+            canManage={canManageExemption}
             isExempt={isExempt}
             isUpdatingExemption={isUpdatingExemption}
             onExemptionChange={handleExemptionChange}
+            exemptionInfo={exemptionInfo}
             disabled={readOnly}
           />
         </DialogContent>

--- a/src/components/athlete-card/ExemptionCheckbox.tsx
+++ b/src/components/athlete-card/ExemptionCheckbox.tsx
@@ -1,23 +1,55 @@
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Checkbox } from "@/components/ui/checkbox";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface ExemptionInfo {
+  isento_por_nome: string | null;
+  isento_justificativa: string | null;
+}
 
 interface ExemptionCheckboxProps {
-  isCurrentUser: boolean;
+  canManage: boolean;
   isExempt: boolean;
   isUpdatingExemption: boolean;
-  onExemptionChange: (checked: boolean) => void;
+  onExemptionChange: (checked: boolean, justificativa?: string) => void;
+  exemptionInfo?: ExemptionInfo | null;
   disabled?: boolean;
 }
 
 export const ExemptionCheckbox: React.FC<ExemptionCheckboxProps> = ({
-  isCurrentUser,
+  canManage,
   isExempt,
   isUpdatingExemption,
   onExemptionChange,
+  exemptionInfo,
   disabled
 }) => {
-  if (!isCurrentUser) return null;
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [justificativa, setJustificativa] = useState('');
+
+  if (!canManage) return null;
+
+  const handleToggle = (checked: boolean) => {
+    if (checked) {
+      // Isentar exige justificativa → abre o diálogo
+      setJustificativa('');
+      setDialogOpen(true);
+    } else {
+      // Remover isenção não exige justificativa
+      onExemptionChange(false);
+    }
+  };
+
+  const handleConfirm = () => {
+    if (!justificativa.trim()) return;
+    onExemptionChange(true, justificativa.trim());
+    setDialogOpen(false);
+  };
 
   return (
     <div className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
@@ -25,7 +57,7 @@ export const ExemptionCheckbox: React.FC<ExemptionCheckboxProps> = ({
         <Checkbox
           id="exempt-checkbox"
           checked={isExempt}
-          onCheckedChange={onExemptionChange}
+          onCheckedChange={handleToggle}
           disabled={isUpdatingExemption || !!disabled}
         />
         <label htmlFor="exempt-checkbox" className="text-sm font-medium text-blue-700">
@@ -35,11 +67,46 @@ export const ExemptionCheckbox: React.FC<ExemptionCheckboxProps> = ({
           <div className="text-xs text-blue-600">Atualizando...</div>
         )}
       </div>
+
       {isExempt && (
-        <div className="mt-2 text-xs text-blue-600">
-          ✓ Você está marcado como isento deste evento
+        <div className="mt-2 text-xs text-blue-600 space-y-0.5">
+          {exemptionInfo?.isento_por_nome && (
+            <p>✓ Isento por {exemptionInfo.isento_por_nome}</p>
+          )}
+          {exemptionInfo?.isento_justificativa && (
+            <p className="italic">Justificativa: {exemptionInfo.isento_justificativa}</p>
+          )}
+          {!exemptionInfo?.isento_por_nome && <p>✓ Atleta marcado como isento deste evento</p>}
         </div>
       )}
+
+      <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Conceder isenção</AlertDialogTitle>
+            <AlertDialogDescription>
+              O valor do pagamento será zerado e a isenção ficará registrada em seu nome.
+              Informe o motivo da isenção.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Textarea
+            value={justificativa}
+            onChange={(e) => setJustificativa(e.target.value)}
+            placeholder="Ex.: pagou a taxa internacional da EECC junto com as Olimpíadas Internacionais"
+            className="min-h-[90px]"
+            autoFocus
+          />
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => { e.preventDefault(); handleConfirm(); }}
+              disabled={!justificativa.trim()}
+            >
+              Confirmar isenção
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/src/components/athlete-card/hooks/useExemptionStatus.ts
+++ b/src/components/athlete-card/hooks/useExemptionStatus.ts
@@ -4,129 +4,105 @@ import { useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
 import { toast } from 'sonner';
 
+interface ExemptionInfo {
+  isento_por: string | null;
+  isento_em: string | null;
+  isento_justificativa: string | null;
+  isento_por_nome: string | null;
+}
+
 interface UseExemptionStatusProps {
   userId: string;
   eventId: string;
-  isCurrentUser: boolean;
+  canManage: boolean;
   refetchPayment: () => Promise<any>;
 }
 
-export const useExemptionStatus = ({ 
-  userId, 
-  eventId, 
-  isCurrentUser, 
-  refetchPayment 
+export const useExemptionStatus = ({
+  userId,
+  eventId,
+  canManage,
+  refetchPayment
 }: UseExemptionStatusProps) => {
   const [isExempt, setIsExempt] = useState(false);
   const [isUpdatingExemption, setIsUpdatingExemption] = useState(false);
+  const [exemptionInfo, setExemptionInfo] = useState<ExemptionInfo | null>(null);
   const queryClient = useQueryClient();
 
-  // Check if user is exempt using pagamentos table
+  // Lê o estado de isenção (só para quem gerencia)
   useEffect(() => {
     const checkExemptionStatus = async () => {
-      if (!isCurrentUser) return;
-      
+      if (!canManage) return;
+
       try {
-        console.log('Checking exemption status for user:', userId, 'event:', eventId);
-        
         const { data, error } = await supabase
           .from('pagamentos')
-          .select('isento, status')
+          .select('isento, status, isento_por, isento_em, isento_justificativa')
           .eq('atleta_id', userId)
           .eq('evento_id', eventId)
           .single();
-        
+
         if (error) {
-          console.error('Error checking exemption status:', error);
-          // If no payment record exists, assume not exempt
           setIsExempt(false);
+          setExemptionInfo(null);
           return;
         }
-        
-        console.log('Exemption data:', data);
-        // Consider exempt if either isento flag is true OR status is "isento"
-        setIsExempt(data?.isento || data?.status === 'isento');
+
+        const exempt = !!data?.isento || data?.status === 'isento';
+        setIsExempt(exempt);
+
+        if (exempt && data?.isento_por) {
+          const { data: grantor } = await supabase
+            .from('usuarios')
+            .select('nome_completo')
+            .eq('id', data.isento_por)
+            .single();
+          setExemptionInfo({
+            isento_por: data.isento_por,
+            isento_em: data.isento_em,
+            isento_justificativa: data.isento_justificativa,
+            isento_por_nome: grantor?.nome_completo ?? null,
+          });
+        } else {
+          setExemptionInfo(null);
+        }
       } catch (error) {
         console.error('Error in checkExemptionStatus:', error);
         setIsExempt(false);
+        setExemptionInfo(null);
       }
     };
 
     checkExemptionStatus();
-  }, [isCurrentUser, userId, eventId]);
+  }, [canManage, userId, eventId]);
 
-  const handleExemptionChange = async (checked: boolean) => {
-    if (!isCurrentUser) return;
-    
+  const handleExemptionChange = async (checked: boolean, justificativa?: string) => {
+    if (!canManage) return;
+
     setIsUpdatingExemption(true);
-    console.log('Updating exemption status:', { 
-      userId, 
-      eventId, 
-      checked 
-    });
-    
     try {
-      // First, check if payment record exists
-      const { data: existingPayment, error: checkError } = await supabase
-        .from('pagamentos')
-        .select('id, isento, valor, status, taxas_inscricao ( valor )')
-        .eq('atleta_id', userId)
-        .eq('evento_id', eventId)
-        .single();
+      const { error } = await supabase.rpc('conceder_isencao', {
+        p_atleta_id: userId,
+        p_evento_id: eventId,
+        p_isento: checked,
+        p_justificativa: justificativa ?? null,
+      });
 
-      if (checkError && checkError.code !== 'PGRST116') {
-        console.error('Error checking existing payment record:', checkError);
-        throw new Error('Erro ao verificar registro de pagamento');
+      if (error) {
+        console.error('Error updating exemption via RPC:', error);
+        throw new Error(error.message);
       }
-
-      console.log('Existing payment record:', existingPayment);
-
-      // If payment record doesn't exist, we need to create one first
-      if (!existingPayment) {
-        console.log('Payment record not found, cannot update exemption status');
-        throw new Error('Registro de pagamento não encontrado. O pagamento deve ser criado primeiro.');
-      }
-
-      // Ao desmarcar, o valor atual já foi zerado pela isenção — restaurar da taxa vinculada
-      const taxaValor = (existingPayment.taxas_inscricao as any)?.valor ?? existingPayment.valor;
-
-      // Update exemption status in pagamentos table
-      const updateData: any = {
-        isento: checked,
-        status: checked ? 'isento' : 'pendente', // Set status to "isento" when exempt, "pendente" when not
-        valor: checked ? 0 : taxaValor
-      };
-
-      console.log('Updating payment with data:', updateData);
-
-      const { error: updateError } = await supabase
-        .from('pagamentos')
-        .update(updateData)
-        .eq('atleta_id', userId)
-        .eq('evento_id', eventId);
-
-      if (updateError) {
-        console.error('Error updating exemption in payments:', updateError);
-        throw updateError;
-      }
-
-      console.log('Exemption updated successfully');
 
       setIsExempt(checked);
       await refetchPayment();
-      
-      // Invalidate queries to refresh the data
-      await queryClient.invalidateQueries({ 
-        queryKey: ['athlete-management', eventId]
-      });
-      await queryClient.invalidateQueries({ 
-        queryKey: ['branch-analytics', eventId]
-      });
 
-      toast.success(checked ? 'Marcado como isento com sucesso!' : 'Isenção removida com sucesso!');
+      await queryClient.invalidateQueries({ queryKey: ['athlete-management', eventId] });
+      await queryClient.invalidateQueries({ queryKey: ['branch-analytics', eventId] });
+
+      toast.success(checked ? 'Atleta marcado como isento!' : 'Isenção removida com sucesso!');
     } catch (error: any) {
       console.error('Error updating exemption:', error);
-      toast.error('Erro ao atualizar status de isenção: ' + (error.message || 'Erro desconhecido'));
+      toast.error('Erro ao atualizar isenção: ' + (error.message || 'Erro desconhecido'));
     } finally {
       setIsUpdatingExemption(false);
     }
@@ -135,6 +111,7 @@ export const useExemptionStatus = ({
   return {
     isExempt,
     isUpdatingExemption,
+    exemptionInfo,
     handleExemptionChange
   };
 };

--- a/supabase/migrations/20260702_isencao_com_auditoria.sql
+++ b/supabase/migrations/20260702_isencao_com_auditoria.sql
@@ -1,0 +1,129 @@
+-- Isenção de atletas por ADM/ORG/RDD, com justificativa obrigatória e auditoria.
+--
+-- Antes: isenção era UPDATE direto do front em pagamentos, gated só por
+-- isCurrentUser (atleta zerava o próprio pagamento, sem registro).
+-- Agora: RPC SECURITY DEFINER valida o papel do chamador (auth.uid()),
+-- registra quem concedeu + justificativa, e grava no audit log.
+--
+-- EXECUTAR MANUALMENTE no SQL Editor de sb.nova-acropole.org.br.
+
+-- 1. Colunas de estado da isenção em pagamentos
+ALTER TABLE public.pagamentos
+  ADD COLUMN IF NOT EXISTS isento_justificativa text,
+  ADD COLUMN IF NOT EXISTS isento_por uuid REFERENCES public.usuarios(id),
+  ADD COLUMN IF NOT EXISTS isento_em timestamptz;
+
+-- 2. Tabela de auditoria (espelha chamadas_audit_log)
+CREATE TABLE IF NOT EXISTS public.pagamentos_audit_log (
+  id            bigserial PRIMARY KEY,
+  operation     text        NOT NULL CHECK (operation IN ('ISENTAR', 'REMOVER_ISENCAO')),
+  atleta_id     uuid,
+  evento_id     uuid,
+  old_data      jsonb,
+  new_data      jsonb,
+  justificativa text,
+  user_id       uuid        REFERENCES public.usuarios(id),
+  "timestamp"   timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.pagamentos_audit_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS pagamentos_audit_select ON public.pagamentos_audit_log;
+CREATE POLICY pagamentos_audit_select ON public.pagamentos_audit_log
+  FOR SELECT TO authenticated USING (true);
+
+GRANT SELECT ON public.pagamentos_audit_log TO authenticated;
+
+-- 3. RPC que centraliza a concessão/remoção de isenção
+CREATE OR REPLACE FUNCTION public.conceder_isencao(
+  p_atleta_id     uuid,
+  p_evento_id     uuid,
+  p_isento        boolean,
+  p_justificativa text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid           uuid := auth.uid();
+  v_is_admin_org  boolean;
+  v_is_rdd        boolean;
+  v_atleta_filial uuid;
+  v_pag           public.pagamentos%ROWTYPE;
+  v_taxa_valor    numeric;
+  v_old           jsonb;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Usuário não autenticado';
+  END IF;
+
+  -- Papéis do chamador no evento
+  SELECT
+    bool_or(pt.codigo IN ('ADM', 'ORG', 'ORE')),
+    bool_or(pt.codigo = 'RDD')
+  INTO v_is_admin_org, v_is_rdd
+  FROM public.papeis_usuarios pu
+    JOIN public.perfis p ON p.id = pu.perfil_id
+    JOIN public.perfis_tipo pt ON pt.id = p.perfil_tipo_id
+  WHERE pu.usuario_id = v_uid
+    AND pu.evento_id = p_evento_id;
+
+  -- Autorização
+  IF COALESCE(v_is_admin_org, false) THEN
+    NULL; -- ADM/ORG: qualquer atleta do evento
+  ELSIF COALESCE(v_is_rdd, false) THEN
+    SELECT filial_id INTO v_atleta_filial FROM public.usuarios WHERE id = p_atleta_id;
+    IF v_atleta_filial IS NULL
+       OR v_atleta_filial <> ALL (public.get_user_delegacao_filiais(v_uid, p_evento_id)) THEN
+      RAISE EXCEPTION 'Sem permissão: atleta fora da sua delegação';
+    END IF;
+  ELSE
+    RAISE EXCEPTION 'Sem permissão para conceder isenção';
+  END IF;
+
+  -- Pagamento alvo
+  SELECT * INTO v_pag FROM public.pagamentos
+   WHERE atleta_id = p_atleta_id AND evento_id = p_evento_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Registro de pagamento não encontrado para este atleta/evento';
+  END IF;
+
+  v_old := to_jsonb(v_pag);
+
+  IF p_isento THEN
+    IF p_justificativa IS NULL OR btrim(p_justificativa) = '' THEN
+      RAISE EXCEPTION 'Justificativa obrigatória para isentar';
+    END IF;
+    UPDATE public.pagamentos
+    SET isento = true,
+        status = 'isento',
+        valor = 0,
+        isento_justificativa = p_justificativa,
+        isento_por = v_uid,
+        isento_em = now()
+    WHERE id = v_pag.id;
+  ELSE
+    SELECT valor INTO v_taxa_valor FROM public.taxas_inscricao WHERE id = v_pag.taxa_inscricao_id;
+    UPDATE public.pagamentos
+    SET isento = false,
+        status = 'pendente',
+        valor = COALESCE(v_taxa_valor, v_pag.valor),
+        isento_justificativa = NULL,
+        isento_por = NULL,
+        isento_em = NULL
+    WHERE id = v_pag.id;
+  END IF;
+
+  -- Auditoria
+  INSERT INTO public.pagamentos_audit_log
+    (operation, atleta_id, evento_id, old_data, new_data, justificativa, user_id)
+  SELECT
+    CASE WHEN p_isento THEN 'ISENTAR' ELSE 'REMOVER_ISENCAO' END,
+    p_atleta_id, p_evento_id, v_old, to_jsonb(np), p_justificativa, v_uid
+  FROM public.pagamentos np WHERE np.id = v_pag.id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.conceder_isencao(uuid, uuid, boolean, text) TO authenticated;


### PR DESCRIPTION
## Contexto

"Marcar como isento" so aparecia no proprio perfil do atleta, que podia zerar o proprio pagamento sem justificativa nem registro (brecha financeira). O organizador precisa isentar OUTROS atletas (ex.: quem pagou a taxa internacional da EECC), informando justificativa e registrando quem concedeu.

## Decisoes

- Isencao passa a ser exclusiva de ADM/ORG/RDD (auto-isencao do atleta removida)
- RDD so isenta atletas da propria delegacao; ADM/ORG isentam qualquer atleta do evento

## Mudancas

**Banco (migracao manual `20260702_isencao_com_auditoria.sql`):**
- Colunas `isento_por`, `isento_justificativa`, `isento_em` em `pagamentos`
- Tabela `pagamentos_audit_log` (espelha `chamadas_audit_log`)
- RPC `conceder_isencao(p_atleta_id, p_evento_id, p_isento, p_justificativa)` SECURITY DEFINER:
  - valida papel do chamador via `auth.uid()` (join papeis_usuarios -> perfis -> perfis_tipo)
  - ADM/ORG: qualquer atleta; RDD: so filiais de `get_user_delegacao_filiais`
  - isentar exige justificativa; zera valor; grava isento_por/em/justificativa
  - remover restaura valor da taxa; limpa campos
  - insere linha no audit log

**Frontend:**
- `useExemptionStatus`: usa a RPC (substitui o UPDATE direto, fechando a brecha); expoe `exemptionInfo` (quem concedeu + justificativa)
- `ExemptionCheckbox`: gate por `canManage`; dialogo com justificativa obrigatoria ao isentar; mostra "Isento por {nome}"
- `AthleteRegistrationCard`: calcula `canManageExemption` (ADM/ORG, ou RDD se a filial do atleta esta na sua delegacao)

**Docs:** `docs/PAPEIS_E_PERMISSOES.md` — tabela dos papeis (ADM/ORG/RDD/ATL/PGR/JUZ/MST/FMON) e a permissao de isencao.

## Migracao SQL obrigatoria

Executar no SQL Editor de sb.nova-acropole.org.br:
`supabase/migrations/20260702_isencao_com_auditoria.sql`

## Verificacao
- [x] npx tsc --noEmit sem erros
- [ ] Organizador isenta outro atleta (com justificativa); aparece "Isento por {nome}"
- [ ] RDD isenta so atleta da propria delegacao (erro para os demais)
- [ ] Atleta comum nao ve mais o bloco de isencao
- [ ] pagamentos_audit_log registra a acao
