### PR TITLE
feat: aba Documentacoes na Administracao

### DIFF
--- a/src/components/event-management/EventDocumentationsSection.tsx
+++ b/src/components/event-management/EventDocumentationsSection.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { DOCS, type DocCategory } from '@/lib/docs/registry';
+import { Library } from 'lucide-react';
+
+const CATEGORY_STYLE: Record<DocCategory, string> = {
+  'Referência': 'bg-sky-50 text-sky-700 border-sky-200',
+  'Atualização': 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  'Melhoria': 'bg-violet-50 text-violet-700 border-violet-200',
+  'Correção': 'bg-amber-50 text-amber-700 border-amber-200',
+};
+
+function formatDate(iso: string): string {
+  const [y, m, d] = iso.split('-');
+  if (!y || !m || !d) return iso;
+  return `${d}/${m}/${y}`;
+}
+
+export function EventDocumentationsSection() {
+  const docs = [...DOCS].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  const [selectedSlug, setSelectedSlug] = useState(docs[0]?.slug);
+
+  if (docs.length === 0) {
+    return (
+      <p className="text-center py-16 text-sm text-muted-foreground">
+        Nenhuma documentação disponível no momento.
+      </p>
+    );
+  }
+
+  const selected = docs.find(d => d.slug === selectedSlug) ?? docs[0];
+
+  return (
+    <div className="grid gap-4 md:grid-cols-[280px_1fr]">
+      {/* Lista de documentos */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-sm font-semibold text-foreground px-1">
+          <Library className="h-4 w-4 text-olimpics-green-primary" />
+          Documentos
+        </div>
+        {docs.map(doc => (
+          <button
+            key={doc.slug}
+            type="button"
+            onClick={() => setSelectedSlug(doc.slug)}
+            className={cn(
+              'w-full text-left rounded-lg border p-3 transition-colors hover:bg-muted/50',
+              doc.slug === selected.slug
+                ? 'border-olimpics-green-primary bg-olimpics-green-primary/5'
+                : 'border-border'
+            )}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-sm font-medium text-foreground">{doc.title}</span>
+              <Badge variant="outline" className={cn('text-[10px] font-medium', CATEGORY_STYLE[doc.category])}>
+                {doc.category}
+              </Badge>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground line-clamp-2">{doc.description}</p>
+            <p className="mt-1 text-[10px] text-muted-foreground">Atualizado em {formatDate(doc.updatedAt)}</p>
+          </button>
+        ))}
+      </div>
+
+      {/* Conteúdo do documento selecionado */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="prose prose-sm max-w-none dark:prose-invert">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{selected.content}</ReactMarkdown>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/docs/registry.ts
+++ b/src/lib/docs/registry.ts
@@ -1,0 +1,29 @@
+// Registro central da documentação do sistema exibida na aba "Documentações"
+// (Administração). Para adicionar um novo documento:
+//   1. Crie o arquivo .md em docs/
+//   2. Importe-o aqui com o sufixo ?raw e adicione uma entrada em DOCS
+// O conteúdo é embutido no build (import ?raw do Vite) — sem fetch em runtime.
+
+import papeisPermissoes from '../../../docs/PAPEIS_E_PERMISSOES.md?raw';
+
+export type DocCategory = 'Referência' | 'Atualização' | 'Melhoria' | 'Correção';
+
+export interface DocEntry {
+  slug: string;
+  title: string;
+  description: string;
+  category: DocCategory;
+  updatedAt: string; // 'YYYY-MM-DD'
+  content: string;
+}
+
+export const DOCS: DocEntry[] = [
+  {
+    slug: 'papeis-e-permissoes',
+    title: 'Papéis e Permissões',
+    description: 'Papéis de usuário (ADM/ORG/RDD/…) e a permissão de isenção.',
+    category: 'Referência',
+    updatedAt: '2026-07-02',
+    content: papeisPermissoes,
+  },
+];

--- a/src/pages/Administration.tsx
+++ b/src/pages/Administration.tsx
@@ -8,7 +8,7 @@ import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
-import { Calendar, FileText, Users, BookOpen, Settings, UserCheck, CalendarIcon } from 'lucide-react';
+import { Calendar, FileText, Users, BookOpen, Settings, UserCheck, CalendarIcon, Library } from 'lucide-react';
 import { LoadingState } from '@/components/dashboard/components/LoadingState';
 import { useEventData } from '@/hooks/useEventData';
 import { EventBasicInfo } from '@/components/event-management/EventBasicInfo';
@@ -19,6 +19,7 @@ import { EventRegulationsSection } from '@/components/event-management/EventRegu
 import { ModeloConfigurationSection } from '@/components/event-management/modelo-configuration/ModeloConfigurationSection';
 import { EventProfilesSection } from '@/components/event-management/EventProfilesSection';
 import { EventAdministrationSection } from '@/components/event-management/EventAdministrationSection';
+import { EventDocumentationsSection } from '@/components/event-management/EventDocumentationsSection';
 
 export default function Administration() {
   const navigate = useNavigate();
@@ -130,12 +131,19 @@ export default function Administration() {
                     <Calendar className="h-4 w-4 flex-shrink-0" />
                     <span>{isMobile ? "Modalidades" : "Regras de Modalidades"}</span>
                   </TabsTrigger>
-                  <TabsTrigger 
+                  <TabsTrigger
                     value="modelo-configuration"
                     className="flex items-center gap-1 px-3 py-2 text-sm font-medium data-[state=active]:border-b-2 data-[state=active]:border-olimpics-green-primary rounded-none whitespace-nowrap"
                   >
                     <Settings className="h-4 w-4 flex-shrink-0" />
                     <span>{isMobile ? "Config" : "Configuração de Modelos"}</span>
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="documentations"
+                    className="flex items-center gap-1 px-3 py-2 text-sm font-medium data-[state=active]:border-b-2 data-[state=active]:border-olimpics-green-primary rounded-none whitespace-nowrap"
+                  >
+                    <Library className="h-4 w-4 flex-shrink-0" />
+                    <span>{isMobile ? "Docs" : "Documentações"}</span>
                   </TabsTrigger>
                 </TabsList>
               </div>
@@ -167,6 +175,10 @@ export default function Administration() {
 
                 <TabsContent value="modelo-configuration" className="mt-2 sm:mt-6">
                   <ModeloConfigurationSection eventId={currentEventId} />
+                </TabsContent>
+
+                <TabsContent value="documentations" className="mt-2 sm:mt-6">
+                  <EventDocumentationsSection />
                 </TabsContent>
               </div>
             </Tabs>


### PR DESCRIPTION
## Contexto

Local central, na área do Administrador, para acumular a documentação do sistema (referências, atualizações, melhorias, correções). Primeiro documento: Papéis e Permissões.

## Mudancas

- **Nova aba "Documentações"** em `src/pages/Administration.tsx` (8ª aba; herda o gating ADM da página).
- **`EventDocumentationsSection`**: layout de dois painéis — lista de documentos (título, descrição, badge de categoria, data) + viewer que renderiza o markdown com `react-markdown` + `remark-gfm` e classes `prose` (mesmo padrão da política de privacidade).
- **`src/lib/docs/registry.ts`**: registro central que embute cada `.md` via import `?raw` do Vite (sem fetch em runtime; conteúdo vai no bundle).

## Como adicionar novos docs

1. Criar `docs/NOME.md`.
2. Adicionar uma entrada em `src/lib/docs/registry.ts` (import `?raw` + `{ slug, title, description, category, updatedAt, content }`).

Aparece na aba automaticamente. Categorias disponíveis: Referência, Atualização, Melhoria, Correção.

## Verificacao
- [x] `npx tsc --noEmit` sem erros
- [x] `vite build` OK (o import `?raw` do .md resolve no bundle — 4790 módulos, build completo)
- [ ] Como Administrador: Administração → aba "Documentações" → lista "Papéis e Permissões" → markdown formatado (tabela GFM, títulos, listas)
- [ ] Não-admin não acessa /administration (gating existente inalterado)
