### PR TITLE
fix: garante 1 pagamento por atleta/evento (dedupe + constraint)

### DIFF
--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -78,9 +78,11 @@ export async function submitEventPayment(
         const valor = Array.isArray(taxaInfo) ? taxaInfo[0]?.valor : taxaInfo?.valor || 0;
         const identifier = `PAY-${userId.slice(0, 4)}-${Date.now().toString().slice(-6)}`;
 
+        // upsert por (atleta_id, evento_id): garante 1 pagamento por atleta/evento
+        // e evita corrida do check-then-insert (constraint pagamentos_atleta_evento_unico)
         const { data, error } = await supabase
             .from('pagamentos')
-            .insert({
+            .upsert({
                 atleta_id: userId,
                 evento_id: eventId,
                 taxa_inscricao_id: taxaId,
@@ -90,7 +92,7 @@ export async function submitEventPayment(
                 numero_identificador: identifier,
                 data_criacao: new Date().toISOString(),
                 isento: false
-            })
+            }, { onConflict: 'atleta_id,evento_id' })
             .select()
             .single();
 

--- a/supabase/migrations/20260703_pagamentos_unico_por_evento.sql
+++ b/supabase/migrations/20260703_pagamentos_unico_por_evento.sql
@@ -1,0 +1,50 @@
+-- Garante a invariante "1 pagamento por atleta/evento".
+--
+-- Motivo: a view vw_analytics_inscricoes soma valor dos confirmados sem dedupe
+-- por atleta; sem constraint, uma linha duplicada contaria em dobro no Total Pago.
+-- Esta migração remove eventuais duplicatas e impede novas.
+--
+-- EXECUTAR MANUALMENTE no SQL Editor de sb.nova-acropole.org.br.
+
+-- 1. Dedupe: mantém 1 linha por (atleta_id, evento_id).
+--    Prioridade: confirmado > isento > pendente > cancelado; empate → mais recente.
+WITH ranked AS (
+  SELECT
+    id,
+    row_number() OVER (
+      PARTITION BY atleta_id, evento_id
+      ORDER BY
+        CASE status
+          WHEN 'confirmado' THEN 0
+          WHEN 'isento'     THEN 1
+          WHEN 'pendente'   THEN 2
+          WHEN 'cancelado'  THEN 3
+          ELSE 4
+        END,
+        data_criacao DESC NULLS LAST,
+        id DESC
+    ) AS rn
+  FROM public.pagamentos
+)
+DELETE FROM public.pagamentos p
+USING ranked r
+WHERE p.id = r.id
+  AND r.rn > 1;
+
+-- 2. Constraint única (reexecutável)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pagamentos_atleta_evento_unico'
+  ) THEN
+    ALTER TABLE public.pagamentos
+      ADD CONSTRAINT pagamentos_atleta_evento_unico UNIQUE (atleta_id, evento_id);
+  END IF;
+END$$;
+
+-- 3. Conferência: deve retornar 0 linhas
+SELECT atleta_id, evento_id, count(*)
+FROM public.pagamentos
+GROUP BY atleta_id, evento_id
+HAVING count(*) > 1;


### PR DESCRIPTION
## Contexto

Dois relatos após o deploy da isenção:

### Bug A — isenção sem pedir justificativa
Investigação confirmou que o código atual (PR #53) **já exige** justificativa: a única UI de isenção é o `ExemptionCheckbox` → RPC `conceder_isencao` (diálogo no front + `RAISE EXCEPTION` no servidor se a justificativa vier vazia). Os botões de status só têm pendente/confirmado/cancelado — não há "isento". A falha observada foi **bundle desatualizado** (teste no código antigo, antes do rebuild). **Sem mudança de código para o Bug A** — resolve com rebuild + Ctrl+Shift+R.

### Bug B — Total Pago subiu ao alternar isento→confirmado
Nenhum caminho do fluxo cria linha duplicada (todos os writes são UPDATE filtrados por atleta+evento; sem trigger de INSERT). Porém a view soma `valor WHERE status='confirmado'` **sem dedupe por atleta**, e **não havia constraint** garantindo 1 pagamento por atleta/evento. Este PR impõe essa invariante de forma definitiva.

O agregado atual do evento (via view) mostra Total Pago R$ 320 com 12 confirmados — não aparenta duplicação; o aumento observado foi provavelmente o efeito correto de sair de isento/pendente (não conta) para confirmado (conta).

## Mudancas

**Banco (migracao manual `20260703_pagamentos_unico_por_evento.sql`):**
- Dedupe de eventuais duplicatas: mantem 1 linha por (atleta_id, evento_id), prioridade confirmado > isento > pendente > cancelado, empate pela mais recente
- `UNIQUE (atleta_id, evento_id)` em pagamentos (reexecutavel)
- Query de conferencia ao final (deve dar 0 duplicatas)

**Frontend (`src/services/paymentService.ts`):**
- `submitEventPayment`: INSERT -> upsert `onConflict: 'atleta_id,evento_id'` (fecha a janela de corrida do check-then-insert)

## Diagnostico (rodar no SQL Editor — anon nao le pagamentos por RLS)

```sql
SELECT atleta_id, evento_id, count(*) FROM public.pagamentos
GROUP BY atleta_id, evento_id HAVING count(*) > 1;

SELECT p.id, p.status, p.valor, p.isento, p.data_criacao
FROM public.pagamentos p JOIN public.usuarios u ON u.id = p.atleta_id
WHERE u.email = 'olimarbjunior@gmail.com';
```

## Verificacao
- [x] npx tsc --noEmit sem erros
- [ ] Rodar migracao no SQL Editor; conferencia retorna 0 duplicatas
- [ ] Tentar 2o pagamento p/ mesmo atleta/evento -> bloqueado pela constraint
- [ ] Bug A: apos hard refresh, marcar isento exige justificativa
